### PR TITLE
Add branch validation to release workflows

### DIFF
--- a/.github/workflows/release-narrator.yml
+++ b/.github/workflows/release-narrator.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Validate this is a narrator release
+        run: |
+          if [[ ! "${{ github.event.pull_request.head.ref }}" =~ ^release/narrator-v.*$ ]]; then
+            echo "ERROR: This workflow should only run for narrator releases"
+            echo "Branch: ${{ github.event.pull_request.head.ref }}"
+            exit 1
+          fi
+          echo "✓ Confirmed this is a narrator release"
       
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/release-tyler.yml
+++ b/.github/workflows/release-tyler.yml
@@ -19,6 +19,15 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Validate this is a tyler release
+        run: |
+          if [[ ! "${{ github.event.pull_request.head.ref }}" =~ ^release/tyler-v.*$ ]]; then
+            echo "ERROR: This workflow should only run for tyler releases"
+            echo "Branch: ${{ github.event.pull_request.head.ref }}"
+            exit 1
+          fi
+          echo "✓ Confirmed this is a tyler release"
       
       - name: Install uv
         uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
Introduced steps in release-narrator.yml and release-tyler.yml to ensure workflows only run for their respective release branches. This prevents accidental workflow runs on incorrect branches.