### PR TITLE
Add base_url alias for api_base in Agent model

### DIFF
--- a/packages/tyler/tests/models/test_agent.py
+++ b/packages/tyler/tests/models/test_agent.py
@@ -1668,7 +1668,20 @@ async def test_weave_inference_service_example():
         assert metrics["model"] == "deepseek-ai/DeepSeek-R1-0528" 
 
 
-
+@pytest.mark.asyncio
+async def test_base_url_alias():
+    """Test that base_url is properly aliased to api_base"""
+    # Test 1: Using base_url should set api_base
+    agent1 = Agent(name="TestAgent1", base_url="https://custom-api.example.com/v1")
+    assert agent1.api_base == "https://custom-api.example.com/v1", "base_url should be aliased to api_base"
+    
+    # Test 2: Using api_base directly should still work
+    agent2 = Agent(name="TestAgent2", api_base="https://another-api.example.com/v1")
+    assert agent2.api_base == "https://another-api.example.com/v1", "api_base should work directly"
+    
+    # Test 3: Neither base_url nor api_base provided
+    agent3 = Agent(name="TestAgent3")
+    assert agent3.api_base is None, "api_base should be None when neither is provided"
 
 
 @pytest.mark.asyncio

--- a/packages/tyler/tyler/models/agent.py
+++ b/packages/tyler/tyler/models/agent.py
@@ -144,8 +144,16 @@ This ensures the user can access the file correctly.
         )
 
 class Agent(Model):
+    """Tyler Agent model for AI-powered assistants.
+    
+    The Agent class provides a flexible interface for creating AI agents with tool use,
+    delegation capabilities, and conversation management.
+    
+    Note: You can use either 'api_base' or 'base_url' to specify a custom API endpoint.
+    'base_url' will be automatically mapped to 'api_base' for compatibility with litellm.
+    """
     model_name: str = Field(default="gpt-4.1")
-    api_base: Optional[str] = Field(default=None, description="Custom API base URL for the model provider (e.g., for using alternative inference services)")
+    api_base: Optional[str] = Field(default=None, description="Custom API base URL for the model provider (e.g., for using alternative inference services). You can also use 'base_url' as an alias.")
     extra_headers: Optional[Dict[str, str]] = Field(default=None, description="Additional headers to include in API requests (e.g., for authentication or tracking)")
     temperature: float = Field(default=0.7)
     name: str = Field(default="Tyler")
@@ -170,6 +178,10 @@ class Agent(Model):
     }
 
     def __init__(self, **data):
+        # Handle base_url as an alias for api_base (since litellm uses api_base)
+        if 'base_url' in data and 'api_base' not in data:
+            data['api_base'] = data.pop('base_url')
+            
         super().__init__(**data)
         
         # Generate system prompt once at initialization


### PR DESCRIPTION
The Agent model now supports 'base_url' as an alias for 'api_base' to improve compatibility with different API configurations. Tests have been added to verify that both 'base_url' and 'api_base' are handled correctly, and the class docstring has been updated to document this behavior.