### PR TITLE
Release/space monkey v0.2.0

### DIFF
--- a/packages/space-monkey/pyproject.toml
+++ b/packages/space-monkey/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slide-space-monkey"
-version = "0.1.1"
+version = "0.2.0"
 description = "A simple, powerful way to deploy Tyler AI agents as Slack agents"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/space-monkey/space_monkey/__init__.py
+++ b/packages/space-monkey/space_monkey/__init__.py
@@ -14,7 +14,7 @@ from .message_classifier_prompt import format_classifier_prompt
 from .utils import get_logger
 
 # Version
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 # Main exports
 __all__ = [

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -59,8 +59,11 @@ git checkout -b "$BRANCH_NAME"
 # Now actually bump the version
 python ../../scripts/bump_version.py "$PACKAGE" "$VERSION_TYPE"
 
+# Convert package name to module name (replace hyphens with underscores)
+MODULE_NAME=${PACKAGE//-/_}
+
 # Create git commit
-git add pyproject.toml ${PACKAGE}/__init__.py
+git add pyproject.toml ${MODULE_NAME}/__init__.py
 git commit -m "Bump $PACKAGE version to $NEW_VERSION"
 
 # Push the release branch


### PR DESCRIPTION
This pull request updates the version of the `slide-space-monkey` package from `0.1.1` to `0.2.0` and includes changes to ensure consistency in versioning across the project and scripts. It also improves the release script to handle package names with hyphens more effectively.

### Version updates:

* [`packages/space-monkey/pyproject.toml`](diffhunk://#diff-19fc547233e0de39d46e43a5372ae4f4044b71955924a7872bae6ca4dffc6d03L7-R7): Updated the `version` field to `0.2.0` to reflect the new release.
* [`packages/space-monkey/space_monkey/__init__.py`](diffhunk://#diff-fff6756eda5104ef048bce045660c583c17718646db7af2d294f14a7c7a3587bL17-R17): Updated the `__version__` variable to `0.2.0` for consistency with the new release version.

### Release script improvement:

* [`scripts/release.sh`](diffhunk://#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389R62-R66): Added logic to convert package names with hyphens into module names with underscores, ensuring proper handling during the version bump process. Updated the `git add` command to use the converted module name.