### PR TITLE
Fix lye workflow permissions to allow tag pushing

### DIFF
--- a/.github/workflows/release-lye.yml
+++ b/.github/workflows/release-lye.yml
@@ -8,6 +8,10 @@ on:
     paths:
       - 'packages/lye/**'
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   publish-lye:
     # Only run if PR was merged and branch matches release/lye-v*
@@ -19,6 +23,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Full history for tags
+          token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Validate this is a lye release
         run: |


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the `release-lye` process to enhance permissions and streamline authentication. The changes primarily focus on configuring permissions and ensuring the correct token is used for actions.

### Workflow configuration updates:

* [`.github/workflows/release-lye.yml`](diffhunk://#diff-e4446b062147a7f0d41527d8b47a4a38b84cf2b25511ff85e5fbaf0f6ff6b206R11-R14): Added `permissions` block to grant `contents: write` and `pull-requests: write` permissions.
* [`.github/workflows/release-lye.yml`](diffhunk://#diff-e4446b062147a7f0d41527d8b47a4a38b84cf2b25511ff85e5fbaf0f6ff6b206R26): Updated the `actions/checkout` step to use the `GITHUB_TOKEN` secret for authentication.