### PR TITLE
fix: move agent creation inside async main function in quickstart docs

### DIFF
--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -73,19 +73,19 @@ In this quickstart, you'll build an AI agent that can search the web and analyze
     from tyler import Agent, Thread, Message
     from lye import WEB_TOOLS, IMAGE_TOOLS, FILES_TOOLS
 
-    # Create your agent
-    agent = Agent(
-        name="research-assistant",
-        model_name="gpt-4o",  # Use the model for your API key provider
-        purpose="To help with research and analysis tasks",
-        tools=[
-            *WEB_TOOLS,      # Can search and fetch web content
-            *IMAGE_TOOLS,    # Can analyze and describe images
-            *FILES_TOOLS     # Can read and write files
-        ]
-    )
-
     async def main():
+        # Create your agent
+        agent = Agent(
+            name="research-assistant",
+            model_name="gpt-4o",  # Use the model for your API key provider
+            purpose="To help with research and analysis tasks",
+            tools=[
+                *WEB_TOOLS,      # Can search and fetch web content
+                *IMAGE_TOOLS,    # Can analyze and describe images
+                *FILES_TOOLS     # Can read and write files
+            ]
+        )
+
         # Create a conversation thread
         thread = Thread()
         


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the quickstart documentation where the agent creation was outside the async main function, which would cause a NameError when users tried to run the example.

## Problem
The documentation showed:
```python
agent = Agent(...)  # Outside the function

async def main():
    # Using agent here - would cause NameError
```

## Solution
Moved the agent creation inside the async main function to match the working example in `examples/getting-started/quickstart.py`:
```python
async def main():
    agent = Agent(...)  # Inside the function
    # Now agent is properly scoped
```

## Testing
- The updated code structure matches the working example that successfully runs
- This ensures users following the quickstart guide won't encounter errors

Once merged, Mintlify should automatically deploy the updated documentation.