### PR TITLE
fix: move agent creation inside async functions in multiple docs

### DIFF
--- a/docs/guides/your-first-agent.mdx
+++ b/docs/guides/your-first-agent.mdx
@@ -55,18 +55,17 @@ We'll create an agent that can:
     from tyler import Agent, Thread, Message
     from lye import WEB_TOOLS, FILES_TOOLS
 
-    # Create your agent
-    agent = Agent(
-        name="research-assistant",
-        model_name="gpt-4o",
-        purpose="To help with research by finding, analyzing, and summarizing information",
-        tools=[
-            *WEB_TOOLS,     # Can search and fetch web content
-            *FILES_TOOLS    # Can read and write files
-        ]
-    )
-
     async def main():
+        # Create your agent
+        agent = Agent(
+            name="research-assistant",
+            model_name="gpt-4o",
+            purpose="To help with research by finding, analyzing, and summarizing information",
+            tools=[
+                *WEB_TOOLS,     # Can search and fetch web content
+                *FILES_TOOLS    # Can read and write files
+            ]
+        )
         # Create a conversation thread
         thread = Thread()
         

--- a/docs/packages/tyler/introduction.mdx
+++ b/docs/packages/tyler/introduction.mdx
@@ -88,15 +88,14 @@ import asyncio
 from tyler import Agent, Thread, Message
 from lye import WEB_TOOLS, FILES_TOOLS
 
-# Create an agent with tools
-agent = Agent(
-    name="researcher",
-    model_name="gpt-4",
-    purpose="To help with research tasks",
-    tools=[*WEB_TOOLS, *FILES_TOOLS]
-)
-
 async def main():
+    # Create an agent with tools
+    agent = Agent(
+        name="researcher",
+        model_name="gpt-4",
+        purpose="To help with research tasks",
+        tools=[*WEB_TOOLS, *FILES_TOOLS]
+    )
     # Create thread and message
     thread = Thread()
     message = Message(
@@ -300,14 +299,13 @@ import asyncio
 from tyler import Agent, Thread, Message
 from lye import AUDIO_TOOLS, IMAGE_TOOLS, BROWSER_TOOLS
 
-agent = Agent(
-    name="multimedia-processor",
-    model_name="gpt-4",
-    purpose="To process multimedia content",
-    tools=[*AUDIO_TOOLS, *IMAGE_TOOLS, *BROWSER_TOOLS]
-)
-
 async def main():
+    agent = Agent(
+        name="multimedia-processor",
+        model_name="gpt-4",
+        purpose="To process multimedia content",
+        tools=[*AUDIO_TOOLS, *IMAGE_TOOLS, *BROWSER_TOOLS]
+    )
     thread = Thread()
     message = Message(
         role="user",


### PR DESCRIPTION
Fixed the same async function issue in:
- docs/guides/your-first-agent.mdx
- docs/packages/tyler/introduction.mdx (2 examples)

This ensures all documentation examples follow the same correct pattern where agent instances are created inside async functions to avoid NameError