### PR TITLE
Refactor streaming API to use ExecutionEvent and EventType

### DIFF
--- a/docs/agent-execution-observability-prd.md
+++ b/docs/agent-execution-observability-prd.md
@@ -377,9 +377,9 @@ Since backward compatibility is not required, the migration is straightforward:
 ```python
 # Old API
 thread, messages = await agent.go(thread)
-async for update in agent.go_stream(thread):
-    if update.type == StreamUpdate.Type.CONTENT_CHUNK:
-        print(update.data)
+async for event in agent.go(thread, stream=True):
+    if event.type == EventType.LLM_STREAM_CHUNK:
+        print(event.data.get("content_chunk", ""))
 
 # New API
 result = await agent.go(thread)

--- a/docs/concepts/a2a.mdx
+++ b/docs/concepts/a2a.mdx
@@ -257,6 +257,8 @@ except Exception as e:
 ### Streaming Responses
 
 ```python
+from tyler.models.execution import EventType
+
 # Enable streaming for real-time responses
 thread = Thread()
 thread.add_message(Message(
@@ -264,11 +266,11 @@ thread.add_message(Message(
     content="Delegate to research_agent with streaming: Analyze AI market trends"
 ))
 
-async for update in agent.go_stream(thread):
-    if update.type.name == "CONTENT_CHUNK":
-        print(update.data, end="", flush=True)
-    elif update.type.name == "TOOL_MESSAGE":
-        print(f"\n[Delegating to: {update.data.name}]")
+async for update in agent.go(thread, stream=True):
+    if update.type == EventType.LLM_STREAM_CHUNK:
+        print(update.data.get("content_chunk", ""), end="", flush=True)
+    elif update.type == EventType.TOOL_SELECTED:
+        print(f"\n[Delegating to: {update.data.get('tool_name', '')}]")
 ```
 
 ## A2A vs MCP Comparison

--- a/docs/concepts/how-agents-work.mdx
+++ b/docs/concepts/how-agents-work.mdx
@@ -21,7 +21,7 @@ graph LR
 
 ### Processing Flow
 
-When you call `agent.go()` or `go_stream()`, Tyler follows these steps:
+When you call `agent.go()` (with or without streaming), Tyler follows these steps:
 
 1. **Message Processing**
    - Loads the conversation thread
@@ -31,7 +31,7 @@ When you call `agent.go()` or `go_stream()`, Tyler follows these steps:
 2. **Step Execution** 
    - Makes an LLM call with the current context
    - Processes the response for content and tool calls
-   - Streams responses in real-time (if using `go_stream`)
+   - Streams responses in real-time (if using `stream=True`)
 
 3. **Tool Execution**
    - If tool calls are present, executes them in parallel
@@ -47,7 +47,7 @@ When you call `agent.go()` or `go_stream()`, Tyler follows these steps:
 - **ToolRunner**: Manages the registry of available tools and handles execution
 - **Thread**: Maintains conversation history and context
 - **Message**: Represents user, assistant, and tool messages
-- **StreamUpdate**: Provides real-time updates during streaming
+- **ExecutionEvent**: Provides detailed execution telemetry and streaming updates
 
 ### Error Handling & Limits
 
@@ -193,18 +193,18 @@ final_result = await agent.go(result.thread)
 For long-running tasks or real-time interaction:
 
 ```python
-from tyler import Agent, Thread, Message, StreamUpdate
+from tyler import Agent, Thread, Message
+from tyler.models.execution import ExecutionEvent, EventType
 
 thread = Thread()
 message = Message(role="user", content="Write a detailed analysis of...")
 thread.add_message(message)
 
-async for update in agent.stream(thread):
-    if isinstance(update, StreamUpdate):
-        if update.type == "content":
-            print(update.content, end="", flush=True)
-        elif update.type == "tool_call":
-            print(f"\n[Using tool: {update.tool_name}]")
+async for event in agent.go(thread, stream=True):
+    if event.type == EventType.LLM_STREAM_CHUNK:
+        print(event.data.get("content_chunk", ""), end="", flush=True)
+    elif event.type == EventType.TOOL_SELECTED:
+        print(f"\n[Using tool: {event.data.get('tool_name', '')}]")
 ```
 
 ### Custom System Prompts

--- a/docs/guides/a2a-integration.mdx
+++ b/docs/guides/a2a-integration.mdx
@@ -269,6 +269,8 @@ async def setup_enterprise_network():
 ### Task Streaming and Monitoring
 
 ```python
+from tyler.models.execution import EventType
+
 async def stream_coordinated_task():
     """Example of streaming responses from coordinated agents."""
     
@@ -281,16 +283,16 @@ async def stream_coordinated_task():
     print("🎯 Starting coordinated task execution...")
     print("=" * 50)
     
-    async for update in coordinator.go_stream(thread):
-        if update.type.name == "CONTENT_CHUNK":
-            print(update.data, end="", flush=True)
-        elif update.type.name == "TOOL_MESSAGE":
-            tool_name = update.data.name
+    async for update in coordinator.go(thread, stream=True):
+        if update.type == EventType.LLM_STREAM_CHUNK:
+            print(update.data.get("content_chunk", ""), end="", flush=True)
+        elif update.type == EventType.TOOL_SELECTED:
+            tool_name = update.data.get("tool_name", "")
             if "delegate_to_" in tool_name:
                 agent_name = tool_name.replace("delegate_to_", "")
                 print(f"\n\n🤝 Delegating to {agent_name}...")
             print()
-        elif update.type.name == "COMPLETE":
+        elif update.type == EventType.EXECUTION_COMPLETE:
             print("\n\n✅ Task coordination complete!")
 ```
 

--- a/docs/guides/patterns.mdx
+++ b/docs/guides/patterns.mdx
@@ -368,6 +368,8 @@ class CompositeTools:
 Optimize streaming for better UX:
 
 ```python
+from tyler.models.execution import EventType
+
 class StreamBuffer:
     def __init__(self, buffer_size: int = 10, flush_interval: float = 0.5):
         self.buffer = []
@@ -378,9 +380,9 @@ class StreamBuffer:
     async def process_stream(self, agent: Agent, thread: Thread):
         """Process stream with intelligent buffering"""
         
-        async for update in agent.go_stream(thread):
-            if update.type == StreamUpdate.Type.CONTENT_CHUNK:
-                self.buffer.append(update.data)
+        async for update in agent.go(thread, stream=True):
+            if update.type == EventType.LLM_STREAM_CHUNK:
+                self.buffer.append(update.data.get("content_chunk", ""))
                 
                 # Flush if buffer full or timeout
                 current_time = asyncio.get_event_loop().time()
@@ -391,7 +393,7 @@ class StreamBuffer:
                     self.buffer = []
                     self.last_flush = current_time
             
-            elif update.type == StreamUpdate.Type.COMPLETE:
+            elif update.type == EventType.EXECUTION_COMPLETE:
                 # Flush remaining buffer
                 if self.buffer:
                     yield "".join(self.buffer)

--- a/docs/guides/streaming-responses.mdx
+++ b/docs/guides/streaming-responses.mdx
@@ -24,7 +24,8 @@ The simplest way to stream responses:
 
 ```python
 import asyncio
-from tyler import Agent, Thread, Message, StreamUpdate
+from tyler import Agent, Thread, Message
+from tyler.models.execution import ExecutionEvent, EventType
 
 agent = Agent(
     name="streaming-assistant",
@@ -122,7 +123,8 @@ async def research_with_streaming(topic: str):
 
 ```python
 import asyncio
-from tyler import Agent, Thread, Message, StreamUpdate, ThreadStore
+from tyler import Agent, Thread, Message, ThreadStore
+from tyler.models.execution import ExecutionEvent, EventType
 
 class StreamingChat:
     def __init__(self):
@@ -153,11 +155,11 @@ class StreamingChat:
         
         print("\n🤖 ", end="", flush=True)
         
-        async for update in self.agent.go_stream(self.thread):
-            if update.type == StreamUpdate.Type.CONTENT_CHUNK:
-                print(update.data, end="", flush=True)
-            elif update.type == StreamUpdate.Type.COMPLETE:
-                self.thread = update.data
+        async for update in self.agent.go(self.thread, stream=True):
+            if update.type == EventType.LLM_STREAM_CHUNK:
+                print(update.data.get("content_chunk", ""), end="", flush=True)
+            elif update.type == EventType.EXECUTION_COMPLETE:
+                # Thread is already updated in place
                 await self.thread_store.save_thread(self.thread)
         
         print("\n")
@@ -211,22 +213,22 @@ async def websocket_endpoint(websocket: WebSocket):
         thread.add_message(message)
         
         # Stream response
-        async for update in agent.go_stream(thread):
-            if update.type == StreamUpdate.Type.CONTENT_CHUNK:
+        async for update in agent.go(thread, stream=True):
+            if update.type == EventType.LLM_STREAM_CHUNK:
                 await websocket.send_json({
                     "type": "content",
                     "data": update.data
                 })
             
-            elif update.type == StreamUpdate.Type.TOOL_MESSAGE:
+            elif update.type == EventType.TOOL_SELECTED:
                 await websocket.send_json({
                     "type": "tool",
-                    "name": update.data.name,
-                    "content": update.data.content[:100] + "..."
+                    "name": update.data.get("tool_name", ""),
+                    "content": str(update.data.get("arguments", ""))[:100] + "..."
                 })
             
-            elif update.type == StreamUpdate.Type.COMPLETE:
-                thread = update.data
+            elif update.type == EventType.EXECUTION_COMPLETE:
+                # Thread is already updated in place
                 await websocket.send_json({"type": "complete"})
 ```
 
@@ -248,15 +250,15 @@ async def stream_with_progress():
     tool_count = 0
     content_buffer = []
     
-    async for update in agent.go_stream(thread):
-        if update.type == StreamUpdate.Type.TOOL_MESSAGE:
+    async for update in agent.go(thread, stream=True):
+        if update.type == EventType.TOOL_SELECTED:
             tool_count += 1
             print(f"\r⏳ Processing... ({tool_count} tools used)", end="", flush=True)
         
-        elif update.type == StreamUpdate.Type.CONTENT_CHUNK:
-            content_buffer.append(update.data)
+        elif update.type == EventType.LLM_STREAM_CHUNK:
+            content_buffer.append(update.data.get("content_chunk", ""))
         
-        elif update.type == StreamUpdate.Type.COMPLETE:
+        elif update.type == EventType.EXECUTION_COMPLETE:
             print("\r✅ Complete!" + " " * 30)  # Clear progress
             print("\n🤖 " + "".join(content_buffer))
 ```
@@ -272,15 +274,15 @@ class BufferedStreamer:
         self.buffer_size = buffer_size
     
     async def stream(self, agent, thread):
-        async for update in agent.go_stream(thread):
-            if update.type == StreamUpdate.Type.CONTENT_CHUNK:
-                self.buffer.append(update.data)
+        async for update in agent.go(thread, stream=True):
+            if update.type == EventType.LLM_STREAM_CHUNK:
+                self.buffer.append(update.data.get("content_chunk", ""))
                 
                 if len(self.buffer) >= self.buffer_size:
                     yield "".join(self.buffer)
                     self.buffer = []
             
-            elif update.type == StreamUpdate.Type.COMPLETE:
+            elif update.type == EventType.EXECUTION_COMPLETE:
                 if self.buffer:
                     yield "".join(self.buffer)
                 yield {"type": "complete", "thread": update.data}
@@ -308,13 +310,13 @@ class CancellableStream:
     
     async def stream_with_cancel(self, agent, thread):
         try:
-            async for update in agent.go_stream(thread):
+            async for update in agent.go(thread, stream=True):
                 if self.cancelled:
                     print("\n\n⚠️  Generation cancelled by user")
                     break
                 
-                if update.type == StreamUpdate.Type.CONTENT_CHUNK:
-                    print(update.data, end="", flush=True)
+                if update.type == EventType.LLM_STREAM_CHUNK:
+                    print(update.data.get("content_chunk", ""), end="", flush=True)
         except asyncio.CancelledError:
             print("\n\n⚠️  Stream interrupted")
     
@@ -354,14 +356,14 @@ async def rich_streaming():
     content = ""
     
     with Live(Panel("", title="🤖 Assistant"), refresh_per_second=10) as live:
-        async for update in agent.go_stream(thread):
-            if update.type == StreamUpdate.Type.CONTENT_CHUNK:
-                content += update.data
+        async for update in agent.go(thread, stream=True):
+            if update.type == EventType.LLM_STREAM_CHUNK:
+                content += update.data.get("content_chunk", "")
                 live.update(Panel(Markdown(content), title="🤖 Assistant"))
             
-            elif update.type == StreamUpdate.Type.TOOL_MESSAGE:
+            elif update.type == EventType.TOOL_SELECTED:
                 tool_panel = Panel(
-                    f"Using: {update.data.name}",
+                    f"Using: {update.data.get('tool_name', '')}",
                     title="🔧 Tool",
                     style="yellow"
                 )
@@ -379,9 +381,9 @@ class TokenCounter:
         self.chunks = []
     
     async def count_stream(self, agent, thread):
-        async for update in agent.go_stream(thread):
-            if update.type == StreamUpdate.Type.CONTENT_CHUNK:
-                self.chunks.append(update.data)
+        async for update in agent.go(thread, stream=True):
+            if update.type == EventType.LLM_STREAM_CHUNK:
+                self.chunks.append(update.data.get("content_chunk", ""))
                 # Rough estimate: 1 token ≈ 4 characters
                 self.total_tokens += len(update.data) // 4
                 
@@ -423,28 +425,32 @@ async def process_multiple_streams():
 
 async def collect_stream(agent, thread):
     content = []
-    async for update in agent.go_stream(thread):
-        if update.type == StreamUpdate.Type.CONTENT_CHUNK:
-            content.append(update.data)
+    async for update in agent.go(thread, stream=True):
+        if update.type == EventType.LLM_STREAM_CHUNK:
+            content.append(update.data.get("content_chunk", ""))
     return "".join(content)
 ```
 
 ### 3. Error Handling in Streams
 
 ```python
+from datetime import datetime
+
 async def safe_stream(agent, thread):
     try:
-        async for update in agent.go_stream(thread):
+        async for update in agent.go(thread, stream=True):
             yield update
     except asyncio.TimeoutError:
-        yield StreamUpdate(
-            type=StreamUpdate.Type.ERROR,
-            data="Stream timed out"
+        yield ExecutionEvent(
+            type=EventType.EXECUTION_ERROR,
+            timestamp=datetime.now(),
+            data={"message": "Stream timed out"}
         )
     except Exception as e:
-        yield StreamUpdate(
-            type=StreamUpdate.Type.ERROR,
-            data=f"Stream error: {str(e)}"
+        yield ExecutionEvent(
+            type=EventType.EXECUTION_ERROR,
+            timestamp=datetime.now(),
+            data={"message": f"Stream error: {str(e)}"}
         )
 ```
 
@@ -453,7 +459,8 @@ async def safe_stream(agent, thread):
 ```python
 import asyncio
 from datetime import datetime
-from tyler import Agent, Thread, Message, StreamUpdate
+from tyler import Agent, Thread, Message
+from tyler.models.execution import ExecutionEvent, EventType
 from lye import WEB_TOOLS, FILES_TOOLS
 
 class LiveResearchAssistant:
@@ -487,25 +494,25 @@ class LiveResearchAssistant:
         content_buffer = []
         tool_uses = []
         
-        async for update in self.agent.go_stream(thread):
-            if update.type == StreamUpdate.Type.CONTENT_CHUNK:
-                chunk = update.data
+        async for update in self.agent.go(thread, stream=True):
+            if update.type == EventType.LLM_STREAM_CHUNK:
+                chunk = update.data.get("content_chunk", "")
                 content_buffer.append(chunk)
                 print(chunk, end="", flush=True)
             
-            elif update.type == StreamUpdate.Type.TOOL_MESSAGE:
-                tool_msg = update.data
-                tool_uses.append(tool_msg.name)
+            elif update.type == EventType.TOOL_SELECTED:
+                tool_name = update.data.get("tool_name", "")
+                tool_uses.append(tool_name)
                 
                 # Show tool use inline
-                print(f"\n\n[🔧 {tool_msg.name}]", end="")
-                if tool_msg.name == "web-search":
+                print(f"\n\n[🔧 {tool_name}]", end="")
+                if tool_name == "web-search":
                     print(f" Searching for information...")
-                elif tool_msg.name == "files-write":
+                elif tool_name == "files-write":
                     print(f" Saving report...")
                 print("\n", end="")
             
-            elif update.type == StreamUpdate.Type.COMPLETE:
+            elif update.type == EventType.EXECUTION_COMPLETE:
                 print(f"\n\n{'='*50}")
                 print(f"✅ Research Complete!")
                 print(f"📊 Tools used: {', '.join(set(tool_uses))}")

--- a/packages/tyler/examples/403_a2a_multi_agent.py
+++ b/packages/tyler/examples/403_a2a_multi_agent.py
@@ -235,7 +235,7 @@ async def run_interactive_session(coordinator: Agent, adapter: A2AAdapter):
                     else:
                         print(f"\n\n[🔧 Using tool: {tool_name}]")
                     print()
-                elif update.type.name == "COMPLETE":
+                elif event.type == EventType.EXECUTION_COMPLETE:
                     print(f"\n\n{'='*60}")
                     print("Response complete!")
                     print('='*60)


### PR DESCRIPTION
Updated documentation, examples, and CLI to replace legacy StreamUpdate and go_stream usage with the new agent.go(..., stream=True) API and standardized ExecutionEvent/EventType enums. This unifies streaming event handling, improves code clarity, and aligns all streaming code samples and handlers with the latest Tyler execution model.