### PR TITLE
Add @weave.op decorator to Agent.go method

### DIFF
--- a/packages/tyler/tyler/models/agent.py
+++ b/packages/tyler/tyler/models/agent.py
@@ -710,6 +710,7 @@ class Agent(Model):
     ) -> AsyncGenerator[ExecutionEvent, None]:
         ...
     
+    @weave.op()
     def go(
         self, 
         thread_or_id: Union[Thread, str],


### PR DESCRIPTION
The go method in the Agent class is now decorated with @weave.op(), enabling it to be used as a Weave operation.