### PR TITLE
feat(tyler): Add structured output, validation retry, and tool context injection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,8 @@ jobs:
           uv sync --dev
       
       - name: Run Tyler tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           cd packages/tyler
           uv run pytest tests/
@@ -230,13 +232,19 @@ jobs:
           uv sync --dev
       
       - name: Run example smoke tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           uv run python tests/run_examples.py --smoke --verbose
       
       - name: Test example imports
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           uv run pytest tests/test_examples.py::test_examples_can_be_imported -v
       
       - name: Test examples directory structure
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           uv run pytest tests/test_examples.py::test_examples_directory_structure -v 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,8 +63,6 @@ jobs:
           uv sync --dev
       
       - name: Run Tyler tests
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           cd packages/tyler
           uv run pytest tests/
@@ -232,19 +230,13 @@ jobs:
           uv sync --dev
       
       - name: Run example smoke tests
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           uv run python tests/run_examples.py --smoke --verbose
       
       - name: Test example imports
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           uv run pytest tests/test_examples.py::test_examples_can_be_imported -v
       
       - name: Test examples directory structure
-        env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           uv run pytest tests/test_examples.py::test_examples_directory_structure -v 

--- a/directive/specs/structured-output-and-di/impact.md
+++ b/directive/specs/structured-output-and-di/impact.md
@@ -1,0 +1,37 @@
+# Impact Analysis — Structured Output & Dependency Injection
+
+## Modules/packages likely touched
+- `packages/tyler/tyler/models/execution.py` - Add `structured_data` to `AgentResult`, add `StructuredOutputError`
+- `packages/tyler/tyler/models/agent.py` - Add `response_type`, `retry_config` fields and `tool_context` parameter
+- `packages/tyler/tyler/models/retry_config.py` - New file for `RetryConfig` model
+- `packages/tyler/tyler/utils/tool_runner.py` - Add context injection support
+- `packages/tyler/tyler/__init__.py` - Export new classes
+- `packages/tyler/tests/` - New test files for each feature
+
+## Contracts to update (APIs, events, schemas, migrations)
+- `AgentResult` dataclass: Add optional `structured_data: Optional[BaseModel]` field
+- `Agent.run()` signature: Add `response_type` and `tool_context` optional parameters
+- `Agent.stream()` signature: Add `tool_context` optional parameter (structured output not applicable to streaming)
+- `ToolRunner.run_tool_async()`: Add `context` parameter for injection
+
+## Risks
+- Security: Low risk - context injection is opt-in and controlled by developer
+- Performance/Availability: 
+  - Retry adds latency on validation failures (expected, configurable)
+  - JSON schema mode may have slightly different latency than regular completion
+- Data integrity: 
+  - Pydantic validation ensures data integrity
+  - Risk of LLM not producing valid JSON (handled by retry)
+
+## Observability needs
+- Logs: 
+  - Log when structured output mode is active
+  - Log validation failures and retry attempts
+  - Log when tool context is injected
+- Metrics:
+  - Count of structured output requests
+  - Validation failure rate
+  - Retry success rate
+- Alerts:
+  - None required initially (features are opt-in)
+

--- a/directive/specs/structured-output-and-di/spec.md
+++ b/directive/specs/structured-output-and-di/spec.md
@@ -1,0 +1,81 @@
+# Spec — Structured Output & Dependency Injection
+
+**Feature name**: Structured Output, Validation Retry, and Dependency Injection  
+**One-line summary**: Add Pydantic-validated structured outputs, automatic retry on validation failure, and tool context injection to close feature gaps with Pydantic AI.
+
+---
+
+## Problem
+Developers choosing between AI agent frameworks often select Pydantic AI specifically for its:
+1. **Type-safe structured outputs** - LLM responses validated against Pydantic models
+2. **Automatic retry** - Self-healing when LLM output doesn't match schema
+3. **Dependency injection** - Clean way to pass runtime context (DB, user info) to tools
+
+Slide/Tyler currently lacks these features, making it less attractive for use cases requiring structured data extraction, data pipelines, or multi-tenant applications.
+
+## Goal
+Add three opt-in, non-breaking features to Tyler:
+1. `response_type` parameter for Pydantic-validated structured outputs
+2. `retry_config` for automatic retry on validation failures
+3. `tool_context` for dependency injection into tools
+
+## Success Criteria
+- [ ] Users can pass a Pydantic model as `response_type` and receive validated structured data
+- [ ] Validation failures trigger automatic retry with error feedback to the LLM
+- [ ] Tools can declare a `ctx` parameter to receive injected dependencies
+- [ ] All existing code continues to work unchanged (100% backward compatible)
+- [ ] Unit tests cover all three features with edge cases
+
+## User Story
+As a developer building a data extraction pipeline, I want my agent to return validated Pydantic models so that I can trust the output structure without manual parsing.
+
+As a developer building a multi-tenant app, I want to inject user-specific context (like DB connections, user ID) into my tools so that tools don't need hardcoded dependencies.
+
+## Flow / States
+
+### Structured Output Flow
+1. User creates `Agent` with optional `response_type=MyModel`
+2. User calls `agent.run(thread, response_type=MyModel)` (can override agent default)
+3. Agent adds JSON schema instruction to system prompt
+4. Agent calls LLM with `response_format={"type": "json_schema", ...}`
+5. Agent parses response and validates with Pydantic
+6. On success: returns `AgentResult` with `structured_data` populated
+7. On failure: retries (if configured) or raises `StructuredOutputError`
+
+### Tool Context Flow
+1. User defines tool with `ctx: ToolContext` as first parameter
+2. User calls `agent.run(thread, tool_context={"db": db, "user_id": "123"})`
+3. Tool runner inspects function signature
+4. If `ctx` parameter exists, injects context as first argument
+5. Tool executes with access to dependencies
+
+## Requirements
+- Must be 100% backward compatible (all parameters optional with `None` defaults)
+- Must work with any Pydantic v2 BaseModel
+- Must support both agent-level and per-run `response_type` overrides
+- Must provide clear error messages on validation failure
+- Must not affect streaming behavior for non-structured outputs
+- Must not require changes to existing tool definitions
+
+## Acceptance Criteria
+
+### Structured Output
+- Given an agent with `response_type=Invoice`, when `run()` completes, then `result.structured_data` is a validated `Invoice` instance
+- Given an agent without `response_type`, when `run()` completes, then `result.structured_data` is `None` (existing behavior)
+- Given an LLM response that doesn't match the schema, when `retry_config` is not set, then `StructuredOutputError` is raised
+- Given an LLM response that doesn't match the schema, when `retry_config.max_retries=2`, then the agent retries up to 2 times with error feedback
+
+### Tool Context
+- Given a tool with `ctx: ToolContext` parameter, when `tool_context` is provided, then the tool receives the context
+- Given a tool without `ctx` parameter, when `tool_context` is provided, then the tool is called without context (backward compatible)
+- Given a tool with `ctx` parameter, when `tool_context` is `None`, then `ToolContextError` is raised
+
+### Retry
+- Given `retry_config=RetryConfig(max_retries=3)`, when validation fails, then up to 3 retry attempts are made
+- Given `retry_config=None` (default), when validation fails, then error is raised immediately
+
+## Non-Goals
+- Full generic typing like `RunContext[T]` (can add later, start with dict-based)
+- Streaming structured outputs (structured output requires complete response)
+- Automatic schema inference from tool return types
+

--- a/directive/specs/structured-output-and-di/tdr.md
+++ b/directive/specs/structured-output-and-di/tdr.md
@@ -1,0 +1,340 @@
+# Technical Design Review (TDR) — Structured Output & Dependency Injection
+
+**Author**: AI Agent  
+**Date**: 2024-12-30  
+**Links**: [Spec](./spec.md), [Impact](./impact.md)
+
+---
+
+## 1. Summary
+This TDR covers three related features to close the gap with Pydantic AI:
+1. **Structured Output**: Allow users to specify a Pydantic model as `response_type`, and receive validated structured data from LLM responses
+2. **Validation Retry**: Automatically retry when LLM output fails schema validation, feeding error details back to the model
+3. **Tool Context Injection**: Allow tools to receive runtime dependencies via a `ctx` parameter
+
+All features are opt-in with zero breaking changes.
+
+## 2. Decision Drivers & Non-Goals
+- **Drivers**: Competitive parity with Pydantic AI, developer ergonomics, production reliability
+- **Non-Goals**: 
+  - Full generic `RunContext[T]` typing (future enhancement)
+  - Streaming structured outputs (requires complete response)
+  - Agent-level default `response_type` (start with per-run only)
+
+## 3. Current State — Codebase Map
+
+### Key modules
+- `tyler/models/agent.py`: Agent class with `run()`, `stream()` methods
+- `tyler/models/execution.py`: `AgentResult`, `ExecutionEvent`, `EventType`
+- `tyler/utils/tool_runner.py`: `ToolRunner` class for tool execution
+- `tyler/models/completion_handler.py`: LLM completion handling
+
+### Existing interfaces
+```python
+# Current AgentResult
+@dataclass
+class AgentResult:
+    thread: Thread
+    new_messages: List[Message]
+    content: Optional[str]
+
+# Current run() signature
+async def run(self, thread_or_id: Union[Thread, str]) -> AgentResult
+```
+
+## 4. Proposed Design
+
+### 4.1 New Models
+
+#### RetryConfig
+```python
+# tyler/models/retry_config.py
+from pydantic import BaseModel, Field
+
+class RetryConfig(BaseModel):
+    """Configuration for structured output validation retry."""
+    max_retries: int = Field(default=3, ge=0, le=10)
+    retry_on_validation_error: bool = Field(default=True)
+    backoff_base_seconds: float = Field(default=0.5, ge=0)
+```
+
+#### ToolContext (type alias)
+```python
+# Simple dict-based context for MVP
+ToolContext = Dict[str, Any]
+```
+
+#### Updated AgentResult
+```python
+@dataclass
+class AgentResult:
+    thread: Thread
+    new_messages: List[Message]
+    content: Optional[str]
+    structured_data: Optional[BaseModel] = None  # NEW
+    validation_retries: int = 0  # NEW: number of retries needed
+```
+
+#### New Exceptions
+```python
+class StructuredOutputError(Exception):
+    """Raised when structured output validation fails after retries."""
+    def __init__(self, message: str, validation_errors: List[Dict], last_response: Any):
+        super().__init__(message)
+        self.validation_errors = validation_errors
+        self.last_response = last_response
+
+class ToolContextError(Exception):
+    """Raised when a tool requires context but none was provided."""
+    pass
+```
+
+### 4.2 Agent Changes
+
+#### New Fields
+```python
+class Agent(BaseModel):
+    # ... existing fields ...
+    retry_config: Optional[RetryConfig] = Field(
+        default=None, 
+        description="Configuration for structured output validation retry"
+    )
+```
+
+#### Updated run() Signature
+```python
+async def run(
+    self,
+    thread_or_id: Union[Thread, str],
+    response_type: Optional[Type[BaseModel]] = None,  # NEW
+    tool_context: Optional[Dict[str, Any]] = None,    # NEW
+) -> AgentResult:
+```
+
+### 4.3 Structured Output Flow
+
+```python
+async def _run_with_structured_output(
+    self, 
+    thread: Thread, 
+    response_type: Type[BaseModel],
+    tool_context: Optional[Dict[str, Any]] = None
+) -> AgentResult:
+    """Run agent expecting structured output."""
+    
+    # Generate JSON schema from Pydantic model
+    schema = response_type.model_json_schema()
+    
+    # Build messages with schema instruction
+    messages = self._build_messages_for_structured_output(thread, schema)
+    
+    retry_count = 0
+    max_retries = self.retry_config.max_retries if self.retry_config else 0
+    
+    while True:
+        # Call LLM with JSON schema response format
+        response = await acompletion(
+            model=self.model_name,
+            messages=messages,
+            response_format={
+                "type": "json_schema",
+                "json_schema": {
+                    "name": response_type.__name__,
+                    "schema": schema,
+                    "strict": True
+                }
+            },
+            # ... other params ...
+        )
+        
+        try:
+            # Parse and validate
+            raw_json = json.loads(response.choices[0].message.content)
+            validated = response_type.model_validate(raw_json)
+            
+            return AgentResult(
+                thread=thread,
+                new_messages=[...],
+                content=response.choices[0].message.content,
+                structured_data=validated,
+                validation_retries=retry_count
+            )
+            
+        except ValidationError as e:
+            retry_count += 1
+            
+            if retry_count > max_retries:
+                raise StructuredOutputError(
+                    f"Validation failed after {retry_count} attempts",
+                    validation_errors=e.errors(),
+                    last_response=raw_json
+                )
+            
+            # Add correction message and retry
+            messages.append({
+                "role": "user",
+                "content": f"Your response did not match the required schema.\n\nErrors:\n{e.json()}\n\nPlease correct and try again."
+            })
+            
+            await asyncio.sleep(self.retry_config.backoff_base_seconds * retry_count)
+```
+
+### 4.4 Tool Context Injection
+
+```python
+# In tool_runner.py
+
+async def run_tool_async(
+    self, 
+    tool_name: str, 
+    parameters: Dict[str, Any],
+    context: Optional[Dict[str, Any]] = None  # NEW
+) -> Any:
+    """Execute an async tool, optionally injecting context."""
+    
+    tool = self.tools[tool_name]
+    implementation = tool['implementation']
+    
+    # Check if tool expects context
+    sig = inspect.signature(implementation)
+    params = list(sig.parameters.keys())
+    
+    expects_context = params and params[0] in ('ctx', 'context')
+    
+    if expects_context:
+        if context is None:
+            raise ToolContextError(
+                f"Tool '{tool_name}' requires context but none was provided"
+            )
+        # Inject context as first argument
+        if tool['is_async']:
+            return await implementation(context, **parameters)
+        else:
+            return await asyncio.to_thread(
+                lambda: implementation(context, **parameters)
+            )
+    else:
+        # Standard execution without context
+        if tool['is_async']:
+            return await implementation(**parameters)
+        else:
+            return await asyncio.to_thread(implementation, **parameters)
+```
+
+## 5. Alternatives Considered
+
+### Structured Output
+- **Option A (chosen)**: Per-run `response_type` parameter
+  - Pros: Flexible, explicit, backward compatible
+  - Cons: Must pass on each call
+- **Option B**: Agent-level default `response_type`
+  - Pros: Less repetition
+  - Cons: Less flexible for agents that need different schemas
+  - Decision: Can add later, start simple
+
+### Tool Context
+- **Option A (chosen)**: Dict-based `tool_context`
+  - Pros: Simple, no new types, flexible
+  - Cons: No type checking on context contents
+- **Option B**: Full generic `RunContext[T]`
+  - Pros: Full type safety
+  - Cons: Complex, requires TypeVar handling
+  - Decision: Start with dict, upgrade later if needed
+
+## 6. Data Model & Contract Changes
+
+### AgentResult
+```python
+# Before
+@dataclass
+class AgentResult:
+    thread: Thread
+    new_messages: List[Message]
+    content: Optional[str]
+
+# After
+@dataclass
+class AgentResult:
+    thread: Thread
+    new_messages: List[Message]
+    content: Optional[str]
+    structured_data: Optional[BaseModel] = None
+    validation_retries: int = 0
+```
+
+### Backward Compatibility
+- All new fields have defaults
+- Existing code accessing `result.thread`, `result.content` unchanged
+- New fields only populated when features are used
+
+## 7. Security, Privacy, Compliance
+- No AuthN/AuthZ changes
+- Tool context may contain sensitive data (DB connections, API keys)
+  - Developers are responsible for what they inject
+  - Context is not persisted or logged
+- No PII handling changes
+
+## 8. Observability & Operations
+- Log structured output mode activation at DEBUG level
+- Log validation failures and retry attempts at WARNING level
+- Log context injection at DEBUG level
+- Existing Weave tracing will capture these automatically
+
+## 9. Rollout & Migration
+- No feature flags needed (features are opt-in by design)
+- No data migration required
+- No breaking changes, can release immediately
+
+## 10. Test Strategy & Spec Coverage (TDD)
+
+### Test Files
+- `tests/test_structured_output.py` - Structured output feature
+- `tests/test_retry_config.py` - Retry configuration and behavior
+- `tests/test_tool_context.py` - Context injection
+
+### Test Cases
+
+| Spec Criterion | Test ID |
+|----------------|---------|
+| Structured output returns validated model | `test_structured_output_basic` |
+| No response_type returns None structured_data | `test_structured_output_disabled_by_default` |
+| Validation failure raises StructuredOutputError | `test_validation_failure_raises` |
+| Retry on validation failure | `test_retry_on_validation_failure` |
+| Max retries exceeded | `test_max_retries_exceeded` |
+| Tool with ctx receives context | `test_tool_context_injection` |
+| Tool without ctx ignores context | `test_tool_no_context_backward_compat` |
+| Missing context raises error | `test_tool_missing_context_error` |
+
+## 11. Risks & Open Questions
+- **Risk**: LLM may not support `response_format` with JSON schema
+  - Mitigation: Fall back to instruction-based prompting, document model requirements
+- **Open Question**: Should we support nested Pydantic models?
+  - Resolution: Yes, Pydantic's `model_json_schema()` handles this automatically
+
+## 12. Milestones / Plan
+
+### Phase 1: Core Implementation
+1. Add `RetryConfig` model
+2. Update `AgentResult` with new fields
+3. Add `StructuredOutputError` and `ToolContextError`
+4. Update `Agent.run()` with new parameters
+
+### Phase 2: Structured Output
+1. Implement `_run_with_structured_output()` method
+2. Add retry logic
+3. Write tests
+
+### Phase 3: Tool Context
+1. Update `ToolRunner.run_tool_async()` with context support
+2. Update `Agent` to pass context to tool runner
+3. Write tests
+
+### Phase 4: Documentation
+1. Update docstrings
+2. Add examples
+3. Update API reference
+
+---
+
+**Approval Gate**: Ready for implementation.
+

--- a/docs/api-reference/tyler-agent.mdx
+++ b/docs/api-reference/tyler-agent.mdx
@@ -127,6 +127,35 @@ agent = Agent(
   This parameter is excluded from serialization (recreated on deserialization).
 </ParamField>
 
+<ParamField path="response_type" type="Type[BaseModel] | None" default="None">
+  Optional Pydantic model to enforce structured output from the LLM. When provided, the agent
+  will instruct the LLM to return JSON conforming to this schema and validate the response.
+  The validated model instance is available in `AgentResult.structured_data`.
+  
+  Can be set at the agent level (default for all runs) or overridden per `run()` call.
+  See the [Structured Output Guide](/guides/structured-output) for details.
+</ParamField>
+
+<ParamField path="retry_config" type="RetryConfig | None" default="None">
+  Configuration for automatic retry behavior. When enabled with structured output, the agent
+  will automatically retry LLM calls if validation fails, providing error feedback to help
+  the LLM correct its output.
+  
+  ```python
+  from tyler import RetryConfig
+  
+  agent = Agent(
+      retry_config=RetryConfig(
+          max_retries=3,
+          retry_on_validation_error=True,
+          backoff_base_seconds=1.0
+      )
+  )
+  ```
+  
+  See [RetryConfig](/api-reference/tyler-retryconfig) for all options.
+</ParamField>
+
 ## Creating from Config Files
 
 <ParamField path="Agent.from_config" type="classmethod">
@@ -244,6 +273,61 @@ print(result.thread)  # Updated thread with all messages
 print(result.new_messages)  # New messages added in this turn
 ```
 
+### With Structured Output
+
+Get type-safe, validated responses using Pydantic models:
+
+```python
+from pydantic import BaseModel
+from tyler import Agent, Thread, Message, RetryConfig
+
+class SupportTicket(BaseModel):
+    priority: str
+    category: str
+    summary: str
+
+agent = Agent(
+    name="classifier",
+    model_name="gpt-4o",
+    retry_config=RetryConfig(max_retries=2)  # Retry on validation failure
+)
+
+thread = Thread()
+thread.add_message(Message(role="user", content="My payment failed!"))
+
+# Get structured output
+result = await agent.run(thread, response_type=SupportTicket)
+
+# Access the validated Pydantic model
+ticket: SupportTicket = result.structured_data
+print(f"Priority: {ticket.priority}")
+print(f"Category: {ticket.category}")
+```
+
+### With Tool Context (Dependency Injection)
+
+Inject runtime dependencies into your tools:
+
+```python
+# Define a tool that uses context
+async def get_user_orders(ctx: ToolContext, limit: int = 10) -> str:
+    db = ctx["db"]  # Injected database
+    user_id = ctx["user_id"]  # Injected user ID
+    orders = await db.get_orders(user_id, limit)
+    return f"Found {len(orders)} orders"
+
+# Run with context
+result = await agent.run(
+    thread,
+    tool_context={
+        "db": database,
+        "user_id": current_user.id
+    }
+)
+```
+
+See the [Structured Output Guide](/guides/structured-output) for complete examples.
+
 ### Event Streaming Mode (stream=True or stream="events")
 
 Stream responses as high-level ExecutionEvent objects with full observability:
@@ -326,7 +410,11 @@ class AgentResult:
     thread: Thread  # Updated thread with all messages
     new_messages: List[Message]  # New messages from this execution
     content: Optional[str]  # The final assistant response
+    structured_data: Optional[BaseModel]  # Validated Pydantic model (if response_type used)
 ```
+
+When using `response_type`, the `structured_data` field contains the validated Pydantic model instance.
+See [AgentResult](/api-reference/tyler-agentresult) for full documentation.
 
 ### ExecutionEvent (Streaming)
 

--- a/docs/api-reference/tyler-agent.mdx
+++ b/docs/api-reference/tyler-agent.mdx
@@ -128,9 +128,12 @@ agent = Agent(
 </ParamField>
 
 <ParamField path="response_type" type="Type[BaseModel] | None" default="None">
-  Optional Pydantic model to enforce structured output from the LLM. When provided, the agent
-  will instruct the LLM to return JSON conforming to this schema and validate the response.
-  The validated model instance is available in `AgentResult.structured_data`.
+  Optional Pydantic model to enforce structured output from the LLM. Uses the **output-tool pattern**:
+  your Pydantic schema is registered as a special tool, and `tool_choice="required"` forces the
+  model to call it. The validated model instance is available in `AgentResult.structured_data`.
+  
+  This approach allows regular tools to work alongside structured output. LiteLLM automatically
+  translates `tool_choice` for different providers (OpenAI, Anthropic, Gemini, Bedrock, etc.).
   
   Can be set at the agent level (default for all runs) or overridden per `run()` call.
   See the [Structured Output Guide](/guides/structured-output) for details.
@@ -156,32 +159,20 @@ agent = Agent(
   See [RetryConfig](/api-reference/tyler-retryconfig) for all options.
 </ParamField>
 
-<ParamField path="response_type" type="Type[BaseModel] | None" default="None">
-  Default Pydantic model for structured output. When set, all `run()` calls will return
-  validated structured data in `result.structured_data`. Can be overridden per-run by
-  passing `response_type` to `run()`.
+<ParamField path="response_format" type="Literal['json'] | None" default="None">
+  Simple JSON mode for when you want any valid JSON without schema validation.
+  Pass `response_format="json"` to `run()` to force JSON output.
   
   ```python
-  from pydantic import BaseModel
-  from tyler import Agent
-  
-  class Invoice(BaseModel):
-      invoice_id: str
-      total: float
-  
-  # Agent with default response_type
-  agent = Agent(
-      name="invoice-extractor",
-      model_name="gpt-4o",
-      response_type=Invoice  # Default for all runs
-  )
-  
-  # No need to pass response_type - uses agent's default
-  result = await agent.run(thread)
-  invoice = result.structured_data  # Invoice instance
+  # Get any valid JSON (no schema validation)
+  result = await agent.run(thread, response_format="json")
+  data = json.loads(result.content)  # Parse yourself
   ```
   
-  See [Structured Output Guide](/guides/structured-output) for more examples.
+  <Warning>
+    Cannot be used with `response_type`. Use `response_type` for schema validation,
+    or `response_format="json"` for simple JSON without validation.
+  </Warning>
 </ParamField>
 
 ## Creating from Config Files

--- a/docs/api-reference/tyler-agent.mdx
+++ b/docs/api-reference/tyler-agent.mdx
@@ -156,6 +156,34 @@ agent = Agent(
   See [RetryConfig](/api-reference/tyler-retryconfig) for all options.
 </ParamField>
 
+<ParamField path="response_type" type="Type[BaseModel] | None" default="None">
+  Default Pydantic model for structured output. When set, all `run()` calls will return
+  validated structured data in `result.structured_data`. Can be overridden per-run by
+  passing `response_type` to `run()`.
+  
+  ```python
+  from pydantic import BaseModel
+  from tyler import Agent
+  
+  class Invoice(BaseModel):
+      invoice_id: str
+      total: float
+  
+  # Agent with default response_type
+  agent = Agent(
+      name="invoice-extractor",
+      model_name="gpt-4o",
+      response_type=Invoice  # Default for all runs
+  )
+  
+  # No need to pass response_type - uses agent's default
+  result = await agent.run(thread)
+  invoice = result.structured_data  # Invoice instance
+  ```
+  
+  See [Structured Output Guide](/guides/structured-output) for more examples.
+</ParamField>
+
 ## Creating from Config Files
 
 <ParamField path="Agent.from_config" type="classmethod">

--- a/docs/api-reference/tyler-agentresult.mdx
+++ b/docs/api-reference/tyler-agentresult.mdx
@@ -34,7 +34,8 @@ class AgentResult:
 
 <ParamField path="structured_data" type="Optional[BaseModel]">
   When `response_type` is provided to `agent.run()`, this field contains a validated instance
-  of the Pydantic model. The LLM's JSON response is parsed and validated against the schema.
+  of the Pydantic model. Internally, the agent uses the **output-tool pattern**: your schema
+  becomes a special tool, and when the LLM calls it, the arguments are validated against your model.
   
   ```python
   from pydantic import BaseModel

--- a/docs/api-reference/tyler-agentresult.mdx
+++ b/docs/api-reference/tyler-agentresult.mdx
@@ -15,6 +15,7 @@ class AgentResult:
     thread: Thread                    # Updated thread with new messages
     new_messages: List[Message]       # New messages added during execution
     content: Optional[str]            # Final assistant response content
+    structured_data: Optional[BaseModel]  # Validated Pydantic model (if response_type used)
 ```
 
 ## Properties
@@ -29,6 +30,26 @@ class AgentResult:
 
 <ParamField path="content" type="Optional[str]">
   The final assistant response content. None if no assistant message was generated
+</ParamField>
+
+<ParamField path="structured_data" type="Optional[BaseModel]">
+  When `response_type` is provided to `agent.run()`, this field contains a validated instance
+  of the Pydantic model. The LLM's JSON response is parsed and validated against the schema.
+  
+  ```python
+  from pydantic import BaseModel
+  
+  class Invoice(BaseModel):
+      vendor: str
+      total: float
+  
+  result = await agent.run(thread, response_type=Invoice)
+  invoice: Invoice = result.structured_data
+  print(f"Vendor: {invoice.vendor}, Total: ${invoice.total}")
+  ```
+  
+  Returns `None` if `response_type` was not provided. See the 
+  [Structured Output Guide](/guides/structured-output) for complete usage.
 </ParamField>
 
 
@@ -203,8 +224,55 @@ await store.update_metadata(
 )
 ```
 
+## Structured Output Usage
+
+When using structured output, access the validated data through `structured_data`:
+
+```python
+from pydantic import BaseModel, Field
+from typing import List, Literal
+
+class SupportTicket(BaseModel):
+    priority: Literal["low", "medium", "high"]
+    category: str
+    summary: str = Field(max_length=500)
+    requires_escalation: bool
+
+# Run with response_type
+result = await agent.run(thread, response_type=SupportTicket)
+
+# Access structured data
+if result.structured_data:
+    ticket: SupportTicket = result.structured_data
+    print(f"Priority: {ticket.priority}")
+    print(f"Category: {ticket.category}")
+    print(f"Needs escalation: {ticket.requires_escalation}")
+
+# Raw content is still available
+print(f"Raw JSON: {result.content}")
+```
+
+### Handling Errors
+
+When structured output validation fails after all retries, `StructuredOutputError` is raised:
+
+```python
+from tyler import StructuredOutputError
+
+try:
+    result = await agent.run(thread, response_type=SupportTicket)
+except StructuredOutputError as e:
+    print(f"Failed: {e.message}")
+    print(f"Validation errors: {e.validation_errors}")
+    print(f"Last response: {e.last_response}")
+```
+
+See the [Structured Output Guide](/guides/structured-output) for complete documentation.
+
 ## See Also
 
-- [Thread](/api-reference/tyler-thread) - Conversation management
+- [Thread](/api-reference/narrator-thread) - Conversation management
 - [Agent](/api-reference/tyler-agent) - The main agent class
+- [RetryConfig](/api-reference/tyler-retryconfig) - Retry configuration for structured output
+- [StructuredOutputError](/api-reference/tyler-structuredoutputerror) - Error when validation fails
 - [ExecutionEvent](/api-reference/tyler-executionevent) - Individual execution events (for streaming mode)

--- a/docs/api-reference/tyler-retryconfig.mdx
+++ b/docs/api-reference/tyler-retryconfig.mdx
@@ -1,0 +1,227 @@
+---
+title: 'RetryConfig'
+description: 'Configuration for automatic retry behavior in agent execution'
+---
+
+## Overview
+
+The `RetryConfig` class configures automatic retry behavior for agent operations, particularly useful when using structured output that may fail validation.
+
+## Class Definition
+
+```python
+from pydantic import BaseModel, Field
+
+class RetryConfig(BaseModel):
+    """Configuration for retry behavior in agent execution."""
+    
+    max_retries: int = Field(default=3, ge=0)
+    retry_on_validation_error: bool = Field(default=True)
+    retry_on_tool_error: bool = Field(default=False)
+    backoff_base_seconds: float = Field(default=1.0, ge=0)
+    
+    model_config = {"frozen": True}  # Immutable
+```
+
+## Properties
+
+<ParamField path="max_retries" type="int" default="3">
+  Maximum number of retry attempts for a failed operation. Set to 0 to disable retries entirely.
+  
+  - Minimum value: 0
+  - Each retry includes the error message as feedback to the LLM
+</ParamField>
+
+<ParamField path="retry_on_validation_error" type="bool" default="True">
+  When True, the agent will automatically retry if structured output validation fails.
+  
+  This handles:
+  - `JSONDecodeError` when the LLM returns invalid JSON
+  - `ValidationError` when JSON doesn't match the Pydantic schema
+</ParamField>
+
+<ParamField path="retry_on_tool_error" type="bool" default="False">
+  When True, the agent will retry if a tool execution fails with an exception.
+  
+  Use with caution—some tool errors are not recoverable by retry (e.g., authentication failures).
+</ParamField>
+
+<ParamField path="backoff_base_seconds" type="float" default="1.0">
+  Base delay in seconds for exponential backoff between retries.
+  
+  The actual delay is: `backoff_base_seconds * retry_attempt`
+  - Retry 1: 1.0s delay
+  - Retry 2: 2.0s delay
+  - Retry 3: 3.0s delay
+</ParamField>
+
+## Creating RetryConfig
+
+```python
+from tyler import RetryConfig
+
+# Default configuration (3 retries, validation retry enabled)
+config = RetryConfig()
+
+# Custom configuration
+config = RetryConfig(
+    max_retries=5,
+    retry_on_validation_error=True,
+    retry_on_tool_error=True,
+    backoff_base_seconds=2.0
+)
+
+# Disable retries
+config = RetryConfig(max_retries=0)
+```
+
+## Usage with Agent
+
+### At Agent Creation
+
+```python
+from tyler import Agent, RetryConfig
+
+agent = Agent(
+    name="DataExtractor",
+    model_name="gpt-4o",
+    purpose="To extract structured data from documents",
+    retry_config=RetryConfig(
+        max_retries=3,
+        retry_on_validation_error=True
+    )
+)
+```
+
+### At Runtime
+
+The agent's `retry_config` is used automatically when `response_type` is provided:
+
+```python
+from pydantic import BaseModel
+
+class Invoice(BaseModel):
+    vendor: str
+    total: float
+    items: list[str]
+
+# Retry config is used if structured output validation fails
+result = await agent.run(thread, response_type=Invoice)
+```
+
+## Retry Flow
+
+When a retry occurs:
+
+1. **Error Detection**: The agent catches `JSONDecodeError` or `ValidationError`
+2. **Feedback Message**: An error message is added to the thread explaining what went wrong
+3. **Backoff Delay**: The agent waits `backoff_base_seconds * attempt_number` seconds
+4. **Retry Attempt**: A new LLM call is made with the feedback in context
+5. **Repeat or Fail**: Steps 1-4 repeat until success or `max_retries` is exhausted
+
+```python
+# Example retry flow with max_retries=2
+# 
+# Attempt 1: LLM returns invalid JSON → JSONDecodeError
+# → Add error feedback to thread
+# → Wait 1.0s
+# 
+# Attempt 2: LLM returns JSON but wrong schema → ValidationError  
+# → Add error feedback to thread
+# → Wait 2.0s
+# 
+# Attempt 3: LLM returns valid structured output → Success!
+```
+
+## Error Handling
+
+When all retries are exhausted, `StructuredOutputError` is raised:
+
+```python
+from tyler import Agent, RetryConfig, StructuredOutputError
+
+agent = Agent(
+    name="extractor",
+    retry_config=RetryConfig(max_retries=2)
+)
+
+try:
+    result = await agent.run(thread, response_type=MyModel)
+except StructuredOutputError as e:
+    print(f"Failed: {e.message}")
+    print(f"Validation errors: {e.validation_errors}")
+    print(f"Last response: {e.last_response}")
+```
+
+## Immutability
+
+`RetryConfig` instances are immutable (frozen). Create a new instance to change values:
+
+```python
+config = RetryConfig(max_retries=3)
+
+# ❌ This will raise an error
+config.max_retries = 5
+
+# ✅ Create a new instance instead
+new_config = RetryConfig(
+    max_retries=5,
+    retry_on_validation_error=config.retry_on_validation_error,
+    retry_on_tool_error=config.retry_on_tool_error,
+    backoff_base_seconds=config.backoff_base_seconds
+)
+```
+
+## Best Practices
+
+### Choosing max_retries
+
+```python
+# Simple schemas - fewer retries needed
+RetryConfig(max_retries=2)
+
+# Complex schemas - may need more attempts
+RetryConfig(max_retries=5)
+
+# Critical operations - more retries with longer backoff
+RetryConfig(max_retries=5, backoff_base_seconds=2.0)
+```
+
+### When to Enable tool_error Retry
+
+```python
+# ✅ Good candidates for tool retry
+# - Network timeouts
+# - Rate limiting
+# - Transient API errors
+
+# ❌ Bad candidates (won't help)
+# - Authentication failures
+# - Invalid parameters
+# - Permission denied
+```
+
+### Production Configuration
+
+```python
+# Development - fast iteration
+dev_config = RetryConfig(
+    max_retries=1,
+    backoff_base_seconds=0.5
+)
+
+# Production - reliability focused
+prod_config = RetryConfig(
+    max_retries=3,
+    retry_on_validation_error=True,
+    retry_on_tool_error=False,  # Only retry known-recoverable errors
+    backoff_base_seconds=1.0
+)
+```
+
+## See Also
+
+- [Agent](/api-reference/tyler-agent) - The main agent class
+- [StructuredOutputError](/api-reference/tyler-structuredoutputerror) - Exception raised when retries are exhausted
+- [Structured Output Guide](/guides/structured-output) - Complete guide to structured output
+

--- a/docs/api-reference/tyler-structuredoutputerror.mdx
+++ b/docs/api-reference/tyler-structuredoutputerror.mdx
@@ -1,0 +1,220 @@
+---
+title: 'StructuredOutputError'
+description: 'Exception raised when structured output validation fails after all retry attempts'
+---
+
+## Overview
+
+`StructuredOutputError` is raised when the agent fails to produce valid structured output after exhausting all retry attempts. It provides detailed information about what went wrong, including validation errors and the last LLM response.
+
+## Class Definition
+
+```python
+class StructuredOutputError(Exception):
+    """Exception raised when structured output validation fails."""
+    
+    message: str
+    validation_errors: List[Dict[str, Any]]
+    last_response: Any
+```
+
+## Properties
+
+<ParamField path="message" type="str">
+  A human-readable description of the failure, including the number of attempts made.
+</ParamField>
+
+<ParamField path="validation_errors" type="List[Dict[str, Any]]">
+  List of Pydantic validation errors or custom error dictionaries explaining what was invalid.
+  
+  For Pydantic validation errors, each dict typically contains:
+  - `type`: The error type (e.g., `"missing"`, `"type_error"`)
+  - `loc`: The location in the schema where the error occurred
+  - `msg`: A human-readable error message
+  - `input`: The invalid input value
+</ParamField>
+
+<ParamField path="last_response" type="Any">
+  The raw content from the last LLM response before the error was raised. Useful for debugging what the LLM actually returned.
+</ParamField>
+
+## Basic Usage
+
+```python
+from tyler import Agent, StructuredOutputError, RetryConfig
+from pydantic import BaseModel
+
+class UserProfile(BaseModel):
+    name: str
+    age: int
+    email: str
+
+agent = Agent(
+    name="extractor",
+    model_name="gpt-4o",
+    retry_config=RetryConfig(max_retries=2)
+)
+
+try:
+    result = await agent.run(thread, response_type=UserProfile)
+    profile = result.structured_data
+except StructuredOutputError as e:
+    print(f"Error: {e.message}")
+    # "Failed to get valid structured output after 3 attempts"
+    
+    print(f"Validation errors: {e.validation_errors}")
+    # [{"type": "missing", "loc": ["email"], "msg": "Field required"}]
+    
+    print(f"Last response: {e.last_response}")
+    # '{"name": "John", "age": 30}'  # Missing email field
+```
+
+## Error Types
+
+### JSON Decode Errors
+
+When the LLM returns invalid JSON:
+
+```python
+try:
+    result = await agent.run(thread, response_type=MyModel)
+except StructuredOutputError as e:
+    if any(err.get("type") == "json_decode_error" for err in e.validation_errors):
+        print("LLM returned invalid JSON")
+        print(f"Raw response: {e.last_response}")
+```
+
+### Schema Validation Errors
+
+When JSON is valid but doesn't match the Pydantic schema:
+
+```python
+try:
+    result = await agent.run(thread, response_type=MyModel)
+except StructuredOutputError as e:
+    for error in e.validation_errors:
+        print(f"Field: {error.get('loc')}")
+        print(f"Error: {error.get('msg')}")
+```
+
+### Unexpected Errors
+
+For other errors during structured output processing:
+
+```python
+try:
+    result = await agent.run(thread, response_type=MyModel)
+except StructuredOutputError as e:
+    if any(err.get("type") == "unexpected_error" for err in e.validation_errors):
+        print(f"Unexpected error: {e.validation_errors[0].get('msg')}")
+```
+
+## Handling Strategies
+
+### Graceful Fallback
+
+```python
+async def extract_with_fallback(thread, model_class):
+    try:
+        result = await agent.run(thread, response_type=model_class)
+        return result.structured_data
+    except StructuredOutputError as e:
+        # Fall back to unstructured response
+        result = await agent.run(thread)  # No response_type
+        return {"raw_content": result.content, "error": e.message}
+```
+
+### Retry with Simpler Schema
+
+```python
+class DetailedProfile(BaseModel):
+    name: str
+    email: str
+    phone: str
+    address: str
+    preferences: dict
+
+class SimpleProfile(BaseModel):
+    name: str
+    email: str
+
+async def extract_profile(thread):
+    try:
+        result = await agent.run(thread, response_type=DetailedProfile)
+        return result.structured_data
+    except StructuredOutputError:
+        # Try with simpler schema
+        result = await agent.run(thread, response_type=SimpleProfile)
+        return result.structured_data
+```
+
+### Logging and Monitoring
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+
+async def extract_data(thread, response_type):
+    try:
+        result = await agent.run(thread, response_type=response_type)
+        return result.structured_data
+    except StructuredOutputError as e:
+        logger.error(
+            "Structured output failed",
+            extra={
+                "message": e.message,
+                "validation_errors": e.validation_errors,
+                "last_response_preview": str(e.last_response)[:200],
+                "response_type": response_type.__name__
+            }
+        )
+        raise
+```
+
+## Common Causes
+
+| Cause | Solution |
+|-------|----------|
+| Schema too complex | Simplify the Pydantic model or break into smaller models |
+| Missing field descriptions | Add `Field(description="...")` to help the LLM |
+| Strict constraints | Use looser constraints or handle in post-processing |
+| Model limitations | Use a more capable model (e.g., gpt-4o instead of gpt-3.5) |
+| Ambiguous prompts | Clarify what data you want extracted |
+| Wrong data type | Ensure the input contains the data you're trying to extract |
+
+## Debugging Tips
+
+1. **Check the last response**: The `last_response` field shows exactly what the LLM returned:
+
+```python
+except StructuredOutputError as e:
+    print("LLM returned:", repr(e.last_response))
+```
+
+2. **Inspect validation errors**: The errors show exactly what failed:
+
+```python
+except StructuredOutputError as e:
+    for err in e.validation_errors:
+        print(f"{err.get('loc')}: {err.get('msg')}")
+```
+
+3. **Test your schema manually**:
+
+```python
+from pydantic import ValidationError
+
+test_json = '{"name": "John"}'  # Your LLM's response
+try:
+    MyModel.model_validate_json(test_json)
+except ValidationError as e:
+    print(e.errors())
+```
+
+## See Also
+
+- [RetryConfig](/api-reference/tyler-retryconfig) - Configure retry behavior
+- [AgentResult](/api-reference/tyler-agentresult) - Successful result with structured_data
+- [Structured Output Guide](/guides/structured-output) - Complete usage guide
+

--- a/docs/api-reference/tyler-toolcontext.mdx
+++ b/docs/api-reference/tyler-toolcontext.mdx
@@ -1,0 +1,324 @@
+---
+title: 'ToolContext'
+description: 'Type alias and patterns for dependency injection in tools'
+---
+
+## Overview
+
+`ToolContext` is a type alias for `Dict[str, Any]` that represents the runtime context passed to tool functions. It enables dependency injection, allowing tools to access databases, API clients, user information, and other runtime dependencies.
+
+## Type Definition
+
+```python
+from typing import Dict, Any
+
+# ToolContext is a type alias
+ToolContext = Dict[str, Any]
+```
+
+## Using ToolContext
+
+### In Tool Definitions
+
+Tools that need runtime dependencies declare a `ctx` or `context` parameter as their first argument:
+
+```python
+from tyler import ToolContext
+
+async def get_user_data(ctx: ToolContext, user_id: str) -> str:
+    """Get user data from the database."""
+    db = ctx["db"]
+    user = await db.get_user(user_id)
+    return f"User: {user.name}, Email: {user.email}"
+```
+
+### Passing Context to Agent
+
+When running the agent, provide the context dictionary:
+
+```python
+from tyler import Agent, Thread, Message
+
+agent = Agent(
+    name="assistant",
+    model_name="gpt-4o",
+    tools=[user_data_tool]
+)
+
+result = await agent.run(
+    thread,
+    tool_context={
+        "db": database_connection,
+        "current_user": current_user,
+        "config": app_config
+    }
+)
+```
+
+## Parameter Naming Convention
+
+The tool runner looks for specific parameter names to identify context parameters:
+
+<ParamField path="ctx" type="ToolContext">
+  Preferred short form. Must be the first parameter.
+  
+  ```python
+  async def my_tool(ctx: ToolContext, param: str) -> str:
+      ...
+  ```
+</ParamField>
+
+<ParamField path="context" type="ToolContext">
+  Alternative longer form. Must be the first parameter.
+  
+  ```python
+  async def my_tool(context: ToolContext, param: str) -> str:
+      ...
+  ```
+</ParamField>
+
+<Warning>
+The context parameter **must** be the first parameter in your function signature. If it appears elsewhere, it won't receive the injected context.
+</Warning>
+
+## Common Context Keys
+
+While `ToolContext` is a flexible dictionary, here are common keys used in practice:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `db` | Database | Database connection or ORM session |
+| `current_user` | User | Currently authenticated user object |
+| `user_id` | str | Current user's ID |
+| `config` | dict | Application configuration |
+| `api_client` | Any | External API client instance |
+| `cache` | Cache | Caching layer |
+| `logger` | Logger | Logging instance |
+
+## Examples
+
+### Database Access
+
+```python
+async def query_orders(ctx: ToolContext, status: str, limit: int = 10) -> str:
+    """Query orders from the database."""
+    db = ctx["db"]
+    user_id = ctx["user_id"]
+    
+    orders = await db.query(
+        "SELECT * FROM orders WHERE user_id = ? AND status = ? LIMIT ?",
+        [user_id, status, limit]
+    )
+    
+    return json.dumps([dict(o) for o in orders])
+```
+
+### API Client
+
+```python
+async def send_notification(ctx: ToolContext, message: str, channel: str) -> str:
+    """Send a notification via Slack."""
+    slack = ctx["slack_client"]
+    
+    response = await slack.chat_postMessage(
+        channel=channel,
+        text=message
+    )
+    
+    return f"Notification sent: {response['ts']}"
+```
+
+### User Context
+
+```python
+async def get_personalized_recommendations(ctx: ToolContext, category: str) -> str:
+    """Get recommendations based on user preferences."""
+    user = ctx["current_user"]
+    recommender = ctx["recommendation_service"]
+    
+    recs = await recommender.get_recommendations(
+        user_id=user.id,
+        preferences=user.preferences,
+        category=category
+    )
+    
+    return json.dumps(recs)
+```
+
+### Configuration Access
+
+```python
+async def fetch_external_data(ctx: ToolContext, query: str) -> str:
+    """Fetch data from external API with configured settings."""
+    config = ctx["config"]
+    http_client = ctx["http_client"]
+    
+    api_url = config["external_api_url"]
+    api_key = config["external_api_key"]
+    
+    response = await http_client.get(
+        f"{api_url}/search",
+        params={"q": query},
+        headers={"Authorization": f"Bearer {api_key}"}
+    )
+    
+    return response.text
+```
+
+## Error Handling
+
+### Missing Context
+
+When a tool expects context but none is provided:
+
+```python
+from tyler import ToolContextError
+
+async def requires_db(ctx: ToolContext, query: str) -> str:
+    db = ctx["db"]  # KeyError if 'db' not in context
+    ...
+
+# This raises ToolContextError
+try:
+    result = await agent.run(thread)  # No tool_context!
+except ToolContextError as e:
+    print(f"Missing context: {e}")
+```
+
+### Missing Keys
+
+Handle missing keys gracefully:
+
+```python
+async def flexible_tool(ctx: ToolContext, action: str) -> str:
+    # Check for required keys
+    if "db" not in ctx:
+        raise ValueError("This tool requires 'db' in context")
+    
+    # Use optional keys with defaults
+    logger = ctx.get("logger", logging.getLogger(__name__))
+    cache = ctx.get("cache")
+    
+    if cache:
+        cached = await cache.get(action)
+        if cached:
+            return cached
+    
+    # ... rest of implementation
+```
+
+## Backward Compatibility
+
+Tools without a context parameter work normally:
+
+```python
+# This tool doesn't use context
+async def simple_math(a: int, b: int) -> str:
+    return str(a + b)
+
+# Context is ignored for this tool
+await agent.run(
+    thread,
+    tool_context={"db": database}  # Passed but not used
+)
+```
+
+## Testing with Context
+
+Mock context for testing:
+
+```python
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+@pytest.mark.asyncio
+async def test_query_orders():
+    # Create mock context
+    mock_db = AsyncMock()
+    mock_db.query.return_value = [
+        {"id": 1, "status": "pending"},
+        {"id": 2, "status": "pending"}
+    ]
+    
+    ctx = {
+        "db": mock_db,
+        "user_id": "user_123"
+    }
+    
+    # Call tool directly
+    result = await query_orders(ctx, status="pending", limit=10)
+    
+    # Verify
+    assert "pending" in result
+    mock_db.query.assert_called_once()
+```
+
+## Best Practices
+
+### Type Documentation
+
+Document expected context keys in your tool's docstring:
+
+```python
+async def complex_tool(ctx: ToolContext, param: str) -> str:
+    """
+    Perform a complex operation.
+    
+    Args:
+        ctx: Runtime context containing:
+            - db (Database): Required. Database connection.
+            - cache (Cache): Optional. Caching layer.
+            - config (dict): Required. Application config with 'api_url' key.
+        param: The operation parameter.
+    
+    Returns:
+        Operation result as JSON string.
+    """
+```
+
+### Validation Helper
+
+Create a validation helper for complex context requirements:
+
+```python
+def validate_context(ctx: ToolContext, required: list[str]) -> None:
+    """Validate that context contains required keys."""
+    missing = [key for key in required if key not in ctx]
+    if missing:
+        raise ValueError(f"Context missing required keys: {missing}")
+
+async def my_tool(ctx: ToolContext, param: str) -> str:
+    validate_context(ctx, ["db", "user_id", "config"])
+    ...
+```
+
+### Context Factory
+
+Create context consistently across your application:
+
+```python
+class ToolContextFactory:
+    def __init__(self, db, config):
+        self.db = db
+        self.config = config
+    
+    def create(self, user: User) -> ToolContext:
+        return {
+            "db": self.db,
+            "config": self.config,
+            "current_user": user,
+            "user_id": user.id,
+            "logger": logging.getLogger(f"tools.{user.id}")
+        }
+
+# Usage
+factory = ToolContextFactory(database, app_config)
+result = await agent.run(thread, tool_context=factory.create(current_user))
+```
+
+## See Also
+
+- [Agent](/api-reference/tyler-agent) - Agent.run() with tool_context
+- [Adding Tools](/guides/adding-tools) - Creating custom tools
+- [Structured Output Guide](/guides/structured-output) - Complete guide including tool context
+

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -25,6 +25,7 @@
           "guides/conversation-persistence",
           "guides/streaming-responses",
           "guides/agent-delegation",
+          "guides/structured-output",
           "guides/mcp-integration",
           "guides/a2a-integration",
           "guides/patterns",
@@ -57,6 +58,9 @@
             "pages": [
               "api-reference/tyler-agent",
               "api-reference/tyler-agentresult",
+              "api-reference/tyler-retryconfig",
+              "api-reference/tyler-structuredoutputerror",
+              "api-reference/tyler-toolcontext",
               "api-reference/tyler-executionevent",
               "api-reference/tyler-eventtype"
             ]

--- a/docs/guides/structured-output.mdx
+++ b/docs/guides/structured-output.mdx
@@ -109,12 +109,22 @@ You can set `response_type` on the agent (as a default for all runs) or pass it 
 
 ### How It Works
 
-When you provide a `response_type`:
+When you provide a `response_type`, Slide uses the **output-tool pattern** (the same approach as [Pydantic AI](https://ai.pydantic.dev/output/)):
 
-1. Slide generates a JSON schema from your Pydantic model
-2. The LLM is instructed to return JSON matching that schema
-3. The response is parsed and validated against your model
-4. You get a fully typed Python object in `result.structured_data`
+1. **Schema as Tool**: Your Pydantic model is registered as a special "output tool"
+2. **Forced Tool Call**: The LLM is called with `tool_choice="required"`, ensuring it must call a tool
+3. **Validation**: When the LLM calls the output tool, its arguments are validated against your schema
+4. **Retry on Failure**: If validation fails, an error message is added and the LLM retries
+
+This approach has key advantages over simple JSON mode:
+- **Tools + Structured Output**: Regular tools work alongside structured output in the same conversation
+- **Reliable Output**: `tool_choice="required"` forces the model to respond with structured data
+- **Cross-Provider Support**: LiteLLM translates `tool_choice` for each provider (OpenAI, Anthropic, Gemini, Bedrock, etc.)
+
+<Note>
+  **Azure OpenAI Limitation**: Azure does not currently support `tool_choice="required"`. 
+  If using Azure, set `drop_params=True` on your agent to gracefully fall back.
+</Note>
 
 ### Complex Schemas
 
@@ -210,11 +220,11 @@ except StructuredOutputError as e:
 
 When validation fails and retry is enabled:
 
-1. Slide catches the `ValidationError` or `JSONDecodeError`
-2. An error message is added to the thread explaining what went wrong
-3. The LLM is called again with the feedback
+1. Slide catches the `ValidationError` or `JSONDecodeError` from the output tool arguments
+2. A tool result message with the error details is added to the thread
+3. The LLM is called again with `tool_choice="required"` to try again
 4. This repeats until validation succeeds or `max_retries` is exhausted
-5. If all retries fail, `StructuredOutputError` is raised
+5. If all retries fail, `StructuredOutputError` is raised with the validation history
 
 ### RetryConfig Options
 

--- a/docs/guides/structured-output.mdx
+++ b/docs/guides/structured-output.mdx
@@ -109,7 +109,7 @@ You can set `response_type` on the agent (as a default for all runs) or pass it 
 
 ### How It Works
 
-When you provide a `response_type`, Slide uses the **output-tool pattern** (the same approach as [Pydantic AI](https://ai.pydantic.dev/output/)):
+When you provide a `response_type`, Slide uses the **output-tool pattern**:
 
 1. **Schema as Tool**: Your Pydantic model is registered as a special "output tool"
 2. **Forced Tool Call**: The LLM is called with `tool_choice="required"`, ensuring it must call a tool

--- a/docs/guides/structured-output.mdx
+++ b/docs/guides/structured-output.mdx
@@ -30,40 +30,82 @@ Structured output lets you define a Pydantic model as the expected response form
 
 ### Basic Usage
 
-```python
-from pydantic import BaseModel, Field
-from typing import Literal, List
-from tyler import Agent, Thread, Message
+You can set `response_type` on the agent (as a default for all runs) or pass it per-run:
 
-# 1. Define your output schema
-class SupportTicket(BaseModel):
-    priority: Literal["low", "medium", "high"]
-    category: str
-    summary: str = Field(max_length=500)
-    requires_escalation: bool
+<Tabs>
+  <Tab title="Agent-level default">
+    ```python
+    from pydantic import BaseModel, Field
+    from typing import Literal
+    from tyler import Agent, Thread, Message
 
-# 2. Create an agent
-agent = Agent(
-    name="ticket-classifier",
-    model_name="gpt-4o",
-    purpose="To classify support tickets"
-)
+    # 1. Define your output schema
+    class SupportTicket(BaseModel):
+        priority: Literal["low", "medium", "high"]
+        category: str
+        summary: str = Field(max_length=500)
+        requires_escalation: bool
 
-# 3. Run with response_type
-thread = Thread()
-thread.add_message(Message(
-    role="user",
-    content="My payment failed and I'm locked out of my account!"
-))
+    # 2. Create agent with default response_type
+    agent = Agent(
+        name="ticket-classifier",
+        model_name="gpt-4o",
+        purpose="To classify support tickets",
+        response_type=SupportTicket  # Default for all runs
+    )
 
-result = await agent.run(thread, response_type=SupportTicket)
+    # 3. Run - uses agent's default response_type
+    thread = Thread()
+    thread.add_message(Message(
+        role="user",
+        content="My payment failed and I'm locked out!"
+    ))
 
-# 4. Access the validated data
-ticket: SupportTicket = result.structured_data
-print(f"Priority: {ticket.priority}")      # "high"
-print(f"Category: {ticket.category}")      # "billing"
-print(f"Escalation: {ticket.requires_escalation}")  # True
-```
+    result = await agent.run(thread)  # No need to pass response_type
+
+    # 4. Access the validated data
+    ticket: SupportTicket = result.structured_data
+    print(f"Priority: {ticket.priority}")  # "high"
+    ```
+  </Tab>
+  <Tab title="Per-run override">
+    ```python
+    from pydantic import BaseModel, Field
+    from typing import Literal, List
+    from tyler import Agent, Thread, Message
+
+    class SupportTicket(BaseModel):
+        priority: Literal["low", "medium", "high"]
+        category: str
+        summary: str = Field(max_length=500)
+        requires_escalation: bool
+
+    class Invoice(BaseModel):
+        invoice_id: str
+        total: float
+        items: List[str]
+
+    # Agent without default - flexible for multiple schemas
+    agent = Agent(
+        name="data-extractor",
+        model_name="gpt-4o",
+        purpose="To extract structured data"
+    )
+
+    # Extract a support ticket
+    result1 = await agent.run(thread1, response_type=SupportTicket)
+    ticket = result1.structured_data
+
+    # Same agent, different schema
+    result2 = await agent.run(thread2, response_type=Invoice)
+    invoice = result2.structured_data
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+  Per-run `response_type` always overrides the agent's default. This lets you have a sensible default while retaining flexibility.
+</Note>
 
 ### How It Works
 

--- a/docs/guides/structured-output.mdx
+++ b/docs/guides/structured-output.mdx
@@ -1,0 +1,546 @@
+---
+title: 'Structured output & dependency injection'
+description: 'Get type-safe, validated data from your agents and inject runtime dependencies into tools'
+---
+
+This guide covers two powerful features that enhance agent reliability and code organization: structured output for type-safe LLM responses, and tool context for dependency injection.
+
+**💻 Code Examples**
+
+<CardGroup cols={2}>
+  <Card
+    title="Structured Output"
+    icon="code"
+    href="https://github.com/adamwdraper/slide/blob/main/packages/tyler/examples/600_structured_output.py"
+  >
+    Type-safe agent responses with Pydantic
+  </Card>
+  <Card
+    title="Tool Context"
+    icon="plug"
+    href="https://github.com/adamwdraper/slide/blob/main/packages/tyler/examples/601_tool_context.py"
+  >
+    Inject dependencies into tools
+  </Card>
+</CardGroup>
+
+## Structured Output
+
+Structured output lets you define a Pydantic model as the expected response format from your agent. The LLM will return data that exactly matches your schema, giving you type-safe, validated data directly.
+
+### Basic Usage
+
+```python
+from pydantic import BaseModel, Field
+from typing import Literal, List
+from tyler import Agent, Thread, Message
+
+# 1. Define your output schema
+class SupportTicket(BaseModel):
+    priority: Literal["low", "medium", "high"]
+    category: str
+    summary: str = Field(max_length=500)
+    requires_escalation: bool
+
+# 2. Create an agent
+agent = Agent(
+    name="ticket-classifier",
+    model_name="gpt-4o",
+    purpose="To classify support tickets"
+)
+
+# 3. Run with response_type
+thread = Thread()
+thread.add_message(Message(
+    role="user",
+    content="My payment failed and I'm locked out of my account!"
+))
+
+result = await agent.run(thread, response_type=SupportTicket)
+
+# 4. Access the validated data
+ticket: SupportTicket = result.structured_data
+print(f"Priority: {ticket.priority}")      # "high"
+print(f"Category: {ticket.category}")      # "billing"
+print(f"Escalation: {ticket.requires_escalation}")  # True
+```
+
+### How It Works
+
+When you provide a `response_type`:
+
+1. Slide generates a JSON schema from your Pydantic model
+2. The LLM is instructed to return JSON matching that schema
+3. The response is parsed and validated against your model
+4. You get a fully typed Python object in `result.structured_data`
+
+### Complex Schemas
+
+Structured output supports all Pydantic features:
+
+```python
+from pydantic import BaseModel, Field
+from typing import List, Optional, Literal
+from datetime import date
+
+class LineItem(BaseModel):
+    """A single item in an invoice"""
+    description: str
+    quantity: int = Field(ge=1)
+    unit_price: float = Field(ge=0)
+    
+    @property
+    def total(self) -> float:
+        return self.quantity * self.unit_price
+
+class Invoice(BaseModel):
+    """Extracted invoice data"""
+    vendor_name: str
+    invoice_number: str
+    invoice_date: date
+    due_date: Optional[date] = None
+    items: List[LineItem]
+    currency: Literal["USD", "EUR", "GBP"] = "USD"
+    notes: Optional[str] = None
+    
+    @property
+    def subtotal(self) -> float:
+        return sum(item.total for item in self.items)
+
+# Use it
+result = await agent.run(thread, response_type=Invoice)
+invoice = result.structured_data
+
+print(f"Invoice #{invoice.invoice_number}")
+print(f"Subtotal: {invoice.currency} {invoice.subtotal:.2f}")
+for item in invoice.items:
+    print(f"  - {item.description}: {item.quantity} x {item.unit_price}")
+```
+
+### Default Response Type
+
+You can set a default `response_type` on the agent itself:
+
+```python
+# Agent-level default
+agent = Agent(
+    name="extractor",
+    model_name="gpt-4o",
+    purpose="To extract structured data",
+    response_type=Invoice  # Default for all runs
+)
+
+# Uses agent's default response_type
+result = await agent.run(thread)
+
+# Override for specific run
+result = await agent.run(thread, response_type=SupportTicket)
+```
+
+## Automatic Retry on Validation Failure
+
+Sometimes the LLM might return invalid JSON or data that doesn't match your schema. Use `RetryConfig` to automatically retry with feedback:
+
+```python
+from tyler import Agent, RetryConfig, StructuredOutputError
+
+agent = Agent(
+    name="extractor",
+    model_name="gpt-4o",
+    purpose="To extract structured data",
+    retry_config=RetryConfig(
+        max_retries=3,
+        retry_on_validation_error=True,
+        backoff_base_seconds=1.0
+    )
+)
+
+try:
+    result = await agent.run(thread, response_type=Invoice)
+    invoice = result.structured_data
+except StructuredOutputError as e:
+    print(f"Failed after {e.message}")
+    print(f"Validation errors: {e.validation_errors}")
+    print(f"Last response: {e.last_response}")
+```
+
+### How Retry Works
+
+When validation fails and retry is enabled:
+
+1. Slide catches the `ValidationError` or `JSONDecodeError`
+2. An error message is added to the thread explaining what went wrong
+3. The LLM is called again with the feedback
+4. This repeats until validation succeeds or `max_retries` is exhausted
+5. If all retries fail, `StructuredOutputError` is raised
+
+### RetryConfig Options
+
+```python
+class RetryConfig(BaseModel):
+    max_retries: int = 3          # Number of retry attempts (0 = no retries)
+    retry_on_validation_error: bool = True  # Retry on schema validation failure
+    retry_on_tool_error: bool = False       # Retry on tool execution failure
+    backoff_base_seconds: float = 1.0       # Delay between retries (exponential)
+```
+
+<Tip>
+  The backoff is exponential: 1s → 2s → 4s. This prevents overwhelming the API during transient issues.
+</Tip>
+
+## Tool Context (Dependency Injection)
+
+Tool context lets you inject runtime dependencies (databases, API clients, user info) into your tools without hardcoding them.
+
+### Basic Usage
+
+```python
+from tyler import Agent, Thread, Message, ToolContext
+from typing import Dict, Any
+
+# 1. Define a tool that accepts context
+async def get_user_orders(ctx: ToolContext, limit: int = 10) -> str:
+    """Get orders for the current user."""
+    db = ctx["db"]           # Injected database
+    user_id = ctx["user_id"] # Injected user ID
+    
+    orders = await db.get_orders(user_id, limit)
+    return f"Found {len(orders)} orders"
+
+# 2. Register the tool
+from tyler.utils.tool_runner import tool_runner
+
+tool_runner.register_tool(
+    name="get_user_orders",
+    implementation=get_user_orders,
+    definition={
+        "type": "function",
+        "function": {
+            "name": "get_user_orders",
+            "description": "Get orders for the current user",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {"type": "integer", "default": 10}
+                }
+            }
+        }
+    }
+)
+
+# 3. Create agent with the tool
+agent = Agent(
+    name="order-assistant",
+    model_name="gpt-4o",
+    purpose="To help users with their orders",
+    tools=[tool_runner.get_tool_definition("get_user_orders")]
+)
+
+# 4. Run with tool_context
+result = await agent.run(
+    thread,
+    tool_context={
+        "db": database_connection,
+        "user_id": current_user.id,
+        "config": app_config
+    }
+)
+```
+
+### Context Parameter Convention
+
+Tools receive context through a special first parameter. Use either:
+
+- `ctx: ToolContext` (recommended)
+- `ctx: Dict[str, Any]`
+- `context: ToolContext`
+- `context: Dict[str, Any]`
+
+```python
+# Both work identically
+async def my_tool(ctx: ToolContext, param: str) -> str:
+    ...
+
+async def my_tool(context: Dict[str, Any], param: str) -> str:
+    ...
+```
+
+<Warning>
+  The context parameter MUST be the first parameter in your tool function signature. If it's not first, the tool won't receive the context.
+</Warning>
+
+### Backward Compatibility
+
+Tools without a context parameter continue to work normally:
+
+```python
+# This tool doesn't use context - still works!
+async def simple_tool(query: str) -> str:
+    return f"Searched for: {query}"
+
+# Context is passed but ignored for tools that don't need it
+result = await agent.run(
+    thread,
+    tool_context={"db": database}  # simple_tool won't receive this
+)
+```
+
+### Error Handling
+
+If a tool expects context but none is provided:
+
+```python
+async def requires_db(ctx: ToolContext, user_id: str) -> str:
+    db = ctx["db"]  # Will raise if 'db' not in context
+    ...
+
+# This will raise ToolContextError
+result = await agent.run(thread)  # No tool_context provided!
+
+# Proper usage
+result = await agent.run(thread, tool_context={"db": my_database})
+```
+
+### Use Cases for Tool Context
+
+<AccordionGroup>
+  <Accordion title="Database Access">
+    ```python
+    async def query_database(ctx: ToolContext, sql: str) -> str:
+        db = ctx["db"]
+        results = await db.execute(sql)
+        return json.dumps(results)
+    ```
+  </Accordion>
+  
+  <Accordion title="User Context">
+    ```python
+    async def get_user_preferences(ctx: ToolContext) -> str:
+        user = ctx["current_user"]
+        return json.dumps({
+            "name": user.name,
+            "timezone": user.timezone,
+            "language": user.language
+        })
+    ```
+  </Accordion>
+  
+  <Accordion title="API Clients">
+    ```python
+    async def send_slack_message(ctx: ToolContext, channel: str, text: str) -> str:
+        slack = ctx["slack_client"]
+        await slack.chat_postMessage(channel=channel, text=text)
+        return f"Message sent to {channel}"
+    ```
+  </Accordion>
+  
+  <Accordion title="Feature Flags">
+    ```python
+    async def process_order(ctx: ToolContext, order_id: str) -> str:
+        config = ctx["config"]
+        if config.get("new_checkout_enabled"):
+            return await new_checkout_flow(order_id)
+        return await legacy_checkout_flow(order_id)
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Combining Features
+
+Structured output and tool context work together seamlessly:
+
+```python
+from pydantic import BaseModel
+from typing import List
+from tyler import Agent, Thread, Message, RetryConfig, ToolContext
+
+class OrderSummary(BaseModel):
+    total_orders: int
+    total_value: float
+    recent_orders: List[str]
+
+async def get_order_stats(ctx: ToolContext, user_id: str) -> str:
+    db = ctx["db"]
+    stats = await db.get_user_order_stats(user_id)
+    return json.dumps(stats)
+
+agent = Agent(
+    name="order-analyst",
+    model_name="gpt-4o",
+    purpose="To analyze user orders",
+    tools=[order_stats_tool],
+    retry_config=RetryConfig(max_retries=2)
+)
+
+result = await agent.run(
+    thread,
+    response_type=OrderSummary,       # Structured output
+    tool_context={"db": database}      # Dependency injection
+)
+
+summary: OrderSummary = result.structured_data
+print(f"User has {summary.total_orders} orders worth ${summary.total_value}")
+```
+
+## Streaming with Structured Output
+
+<Warning>
+  Structured output is currently a non-streaming feature. When you use `response_type`, the agent will collect the full response before validating and returning.
+</Warning>
+
+If you need streaming with structured output, you can:
+
+1. Stream for real-time feedback, then parse the final response:
+
+```python
+full_content = ""
+async for event in agent.stream(thread):
+    if event.type == EventType.LLM_STREAM_CHUNK:
+        chunk = event.data.get("content_chunk", "")
+        full_content += chunk
+        print(chunk, end="", flush=True)
+    elif event.type == EventType.EXECUTION_COMPLETE:
+        # Parse after streaming completes
+        data = MyModel.model_validate_json(full_content)
+```
+
+2. Or use non-streaming mode for structured data:
+
+```python
+# For structured data, use non-streaming
+result = await agent.run(thread, response_type=MyModel)
+```
+
+## Best Practices
+
+### Schema Design
+
+<Steps>
+  <Step title="Keep schemas focused">
+    Define schemas for specific use cases rather than trying to capture everything:
+    
+    ```python
+    # ✅ Focused schema
+    class SentimentResult(BaseModel):
+        sentiment: Literal["positive", "negative", "neutral"]
+        confidence: float = Field(ge=0, le=1)
+    
+    # ❌ Too broad
+    class AnalysisResult(BaseModel):
+        sentiment: str
+        entities: List[str]
+        summary: str
+        keywords: List[str]
+        language: str
+        # ... many more fields
+    ```
+  </Step>
+  
+  <Step title="Use Field constraints">
+    Pydantic validators help the LLM produce correct output:
+    
+    ```python
+    class Rating(BaseModel):
+        score: int = Field(ge=1, le=5)  # LLM knows the valid range
+        reason: str = Field(max_length=200)
+    ```
+  </Step>
+  
+  <Step title="Provide descriptions">
+    Field descriptions help the LLM understand what you want:
+    
+    ```python
+    class ContactInfo(BaseModel):
+        email: str = Field(description="Primary email address")
+        phone: Optional[str] = Field(
+            default=None,
+            description="Phone number in E.164 format, e.g., +1234567890"
+        )
+    ```
+  </Step>
+</Steps>
+
+### Tool Context
+
+<Steps>
+  <Step title="Use type hints">
+    Even though context is a dict, document expected keys:
+    
+    ```python
+    async def my_tool(ctx: ToolContext, param: str) -> str:
+        """
+        Args:
+            ctx: Must contain 'db' (Database) and 'user' (User)
+            param: The search query
+        """
+        db: Database = ctx["db"]
+        user: User = ctx["user"]
+    ```
+  </Step>
+  
+  <Step title="Validate early">
+    Check for required keys at the start of your tool:
+    
+    ```python
+    async def my_tool(ctx: ToolContext, param: str) -> str:
+        if "db" not in ctx:
+            raise ValueError("Tool requires 'db' in context")
+        ...
+    ```
+  </Step>
+  
+  <Step title="Keep context minimal">
+    Only pass what's needed:
+    
+    ```python
+    # ✅ Minimal context
+    tool_context={"db": db, "user_id": user.id}
+    
+    # ❌ Passing entire app state
+    tool_context={"app": entire_application_instance}
+    ```
+  </Step>
+</Steps>
+
+## Error Reference
+
+| Error | Cause | Solution |
+|-------|-------|----------|
+| `StructuredOutputError` | LLM failed to produce valid structured output after retries | Check your schema complexity, add more retry attempts, or simplify the prompt |
+| `ToolContextError` | Tool expected context but none provided | Pass `tool_context` to `agent.run()` |
+| `KeyError` in tool | Required key missing from context | Ensure all required keys are in your `tool_context` dict |
+| `ValidationError` | LLM output doesn't match Pydantic schema | The retry mechanism will attempt to fix this; if it persists, simplify your schema |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Testing Agents"
+    icon="vial"
+    href="/guides/testing-agents"
+  >
+    Test structured output and tool context
+  </Card>
+  <Card
+    title="Agent API Reference"
+    icon="book"
+    href="/api-reference/tyler-agent"
+  >
+    Complete Agent documentation
+  </Card>
+  <Card
+    title="RetryConfig API"
+    icon="rotate"
+    href="/api-reference/tyler-retryconfig"
+  >
+    Retry configuration options
+  </Card>
+  <Card
+    title="Advanced Patterns"
+    icon="diagram-project"
+    href="/guides/patterns"
+  >
+    More advanced usage patterns
+  </Card>
+</CardGroup>
+

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -50,13 +50,14 @@ Slide gives you everything you need to build, test, and deploy intelligent AI ag
 
 - **Extensible and open source**: Built on a foundation you can inspect, customize, and contribute to
 - **Flexible with model support**: Compatible with any LLM provider supported by LiteLLM (100+ providers including OpenAI, Anthropic, etc.)
+- **Real-time streaming enabled**: Designed to build interactive applications with streaming responses from both agents and tools
 - **MCP and A2A compatible**: Seamlessly integrated with Model Context Protocol (MCP) servers and Agent-to-Agent (A2A) protocol for multi-agent interoperability
 - **Agent delegation built-in**: Create multi-agent systems where specialized agents collaborate to solve complex tasks
 - **Multimodal by design**: Capable of processing and understanding images, audio, PDFs, and more out of the box
 - **Persistent with conversations**: Equipped with built-in support for threads, messages, and attachments with flexible storage options (in-memory, SQLite, or PostgreSQL)
-- **Ready-to-use with tools**: Packed with built-in tools for web interaction, file handling, and browser automation with support for custom tools
-- **Real-time streaming enabled**: Designed to build interactive applications with streaming responses from both agents and tools
-- **Transparent reasoning**: Access model thinking tokens from OpenAI o1 and Anthropic Claude to see how agents arrive at decisions
+- **Type-safe structured outputs**: Get validated Pydantic models from your agents with automatic retry on validation failure—no more manual JSON parsing
+- **Ready-to-use with tools**: Packed with built-in tools for web interaction, file handling, and browser automation—plus dependency injection via `tool_context` for custom tools
+- **Transparent reasoning**: Access model thinking tokens to see how agents arrive at decisions
 - **Interactive CLI included**: Chat with your agents instantly using the built-in `tyler chat` command, or scaffold new projects with `tyler init`
 - **Evaluation-ready**: Equipped with a framework to test agents safely with mock tools, prebuilt LLM judges, and multi-turn conversation scenarios
 - **Debuggable**: Integrated with W&B Weave for powerful tracing and debugging capabilities
@@ -110,6 +111,13 @@ Slide gives you everything you need to build, test, and deploy intelligent AI ag
     href="/examples/research-assistant"
   >
     Agents that can search, analyze, and synthesize information
+  </Card>
+  <Card
+    title="Data Extraction Pipelines"
+    icon="database"
+    href="/guides/structured-output"
+  >
+    Extract validated, type-safe structured data from documents and conversations
   </Card>
 </CardGroup>
 

--- a/packages/tyler/examples/600_structured_output.py
+++ b/packages/tyler/examples/600_structured_output.py
@@ -1,0 +1,173 @@
+"""Example: Structured Output with Pydantic Models
+
+This example demonstrates how to use the response_type parameter
+to get validated, type-safe structured outputs from your agent.
+
+Features shown:
+- Basic structured output with a Pydantic model
+- Automatic validation of LLM responses
+- Retry on validation failure with retry_config
+- Accessing the validated structured_data
+
+Prerequisites:
+    pip install slide-tyler
+
+Usage:
+    export OPENAI_API_KEY=your-key
+    python 600_structured_output.py
+"""
+import asyncio
+from pydantic import BaseModel, Field
+from typing import List, Literal
+
+from tyler import Agent, Thread, Message, RetryConfig, StructuredOutputError
+
+
+# Define your output schema using Pydantic
+class MovieReview(BaseModel):
+    """A structured movie review."""
+    title: str = Field(description="The movie title")
+    rating: float = Field(ge=0, le=10, description="Rating from 0 to 10")
+    genre: Literal["action", "comedy", "drama", "horror", "sci-fi", "other"]
+    pros: List[str] = Field(description="List of positive aspects")
+    cons: List[str] = Field(description="List of negative aspects")
+    recommended: bool = Field(description="Whether you recommend this movie")
+
+
+class SupportTicket(BaseModel):
+    """A classified support ticket."""
+    priority: Literal["low", "medium", "high", "critical"]
+    category: str
+    summary: str = Field(max_length=200)
+    requires_escalation: bool
+    suggested_actions: List[str]
+
+
+async def basic_structured_output():
+    """Basic example: Get a movie review in structured format."""
+    print("=" * 60)
+    print("Basic Structured Output Example")
+    print("=" * 60)
+    
+    agent = Agent(
+        name="movie-reviewer",
+        model_name="gpt-4.1",
+        purpose="To provide detailed movie reviews"
+    )
+    
+    thread = Thread()
+    thread.add_message(Message(
+        role="user",
+        content="Give me a review of The Matrix (1999)"
+    ))
+    
+    # Use response_type to get structured output
+    result = await agent.run(thread, response_type=MovieReview)
+    
+    # Access the validated Pydantic model
+    review: MovieReview = result.structured_data
+    
+    print(f"\nMovie: {review.title}")
+    print(f"Rating: {review.rating}/10")
+    print(f"Genre: {review.genre}")
+    print(f"Recommended: {'Yes' if review.recommended else 'No'}")
+    print(f"\nPros:")
+    for pro in review.pros:
+        print(f"  ✓ {pro}")
+    print(f"\nCons:")
+    for con in review.cons:
+        print(f"  ✗ {con}")
+    
+    return review
+
+
+async def structured_output_with_retry():
+    """Example with retry configuration for more reliable outputs."""
+    print("\n" + "=" * 60)
+    print("Structured Output with Retry Example")
+    print("=" * 60)
+    
+    # Configure retry behavior for validation failures
+    agent = Agent(
+        name="support-classifier",
+        model_name="gpt-4.1",
+        purpose="To classify and prioritize support tickets",
+        retry_config=RetryConfig(
+            max_retries=3,           # Retry up to 3 times on validation failure
+            backoff_base_seconds=0.5  # Wait 0.5s * attempt between retries
+        )
+    )
+    
+    thread = Thread()
+    thread.add_message(Message(
+        role="user",
+        content="User report: My payment failed twice and now I can't access my account. This is urgent - I have a meeting in 30 minutes that requires this!"
+    ))
+    
+    result = await agent.run(thread, response_type=SupportTicket)
+    
+    ticket: SupportTicket = result.structured_data
+    
+    print(f"\nTicket Classification:")
+    print(f"  Priority: {ticket.priority.upper()}")
+    print(f"  Category: {ticket.category}")
+    print(f"  Summary: {ticket.summary}")
+    print(f"  Escalation needed: {'Yes' if ticket.requires_escalation else 'No'}")
+    print(f"\nSuggested Actions:")
+    for i, action in enumerate(ticket.suggested_actions, 1):
+        print(f"  {i}. {action}")
+    
+    if result.validation_retries > 0:
+        print(f"\n(Note: Required {result.validation_retries} retry attempts)")
+    
+    return ticket
+
+
+async def handling_validation_errors():
+    """Example showing how to handle validation failures."""
+    print("\n" + "=" * 60)
+    print("Handling Validation Errors Example")
+    print("=" * 60)
+    
+    # Agent without retry config - validation failures raise immediately
+    agent = Agent(
+        name="strict-extractor",
+        model_name="gpt-4.1",
+        purpose="To extract structured data"
+        # No retry_config = fail immediately on validation error
+    )
+    
+    thread = Thread()
+    thread.add_message(Message(
+        role="user",
+        content="Review: It was okay I guess."  # Vague - might produce incomplete data
+    ))
+    
+    try:
+        result = await agent.run(thread, response_type=MovieReview)
+        print(f"\nSuccessfully extracted: {result.structured_data.title}")
+    except StructuredOutputError as e:
+        print(f"\nValidation failed!")
+        print(f"Errors: {e.validation_errors}")
+        print(f"Last response: {e.last_response}")
+
+
+async def main():
+    """Run all examples."""
+    # Basic structured output
+    await basic_structured_output()
+    
+    # With retry for reliability
+    await structured_output_with_retry()
+    
+    # Error handling
+    await handling_validation_errors()
+    
+    print("\n" + "=" * 60)
+    print("All examples complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/packages/tyler/examples/600_structured_output.py
+++ b/packages/tyler/examples/600_structured_output.py
@@ -9,6 +9,7 @@ Features shown:
 - Automatic validation of LLM responses
 - Retry on validation failure with retry_config
 - Accessing the validated structured_data
+- Debugging with retry_history (available on AgentResult and Message.metrics)
 
 Prerequisites:
     pip install slide-tyler
@@ -156,6 +157,17 @@ async def structured_output_with_retry():
     
     if result.validation_retries > 0:
         print(f"\n(Note: Required {result.validation_retries} retry attempts)")
+        
+        # Access detailed retry history for debugging (also persisted in Message.metrics)
+        if result.retry_history:
+            print("\nRetry History (for debugging):")
+            for attempt in result.retry_history:
+                print(f"  Attempt {attempt['attempt']}: {attempt['error_type']}")
+                print(f"    Errors: {attempt['errors']}")
+        
+        # Retry history is also stored in the message for post-hoc debugging:
+        # assistant_msg = result.new_messages[-1]
+        # assistant_msg.metrics.get("structured_output", {}).get("retry_history")
     
     return ticket
 

--- a/packages/tyler/examples/601_tool_context.py
+++ b/packages/tyler/examples/601_tool_context.py
@@ -1,0 +1,296 @@
+"""Example: Tool Context Injection (Dependency Injection)
+
+This example demonstrates how to use the tool_context parameter
+to inject dependencies (like databases, API clients, user info)
+into your tools at runtime.
+
+Features shown:
+- Creating tools that accept context
+- Injecting different contexts per request
+- Multi-tenant patterns with user-specific data
+
+Prerequisites:
+    pip install slide-tyler
+
+Usage:
+    export OPENAI_API_KEY=your-key
+    python 601_tool_context.py
+"""
+import asyncio
+from typing import Dict, Any
+from dataclasses import dataclass
+
+from tyler import Agent, Thread, Message, ToolContext
+
+
+# Simulated database
+class MockDatabase:
+    """Simulated database for the example."""
+    def __init__(self):
+        self.orders = {
+            "user_123": [
+                {"id": "ORD-001", "item": "Widget Pro", "total": 99.99},
+                {"id": "ORD-002", "item": "Gadget X", "total": 149.99},
+            ],
+            "user_456": [
+                {"id": "ORD-003", "item": "Thing", "total": 29.99},
+            ]
+        }
+        self.preferences = {
+            "user_123": {"theme": "dark", "notifications": True},
+            "user_456": {"theme": "light", "notifications": False},
+        }
+    
+    async def get_orders(self, user_id: str, limit: int = 10):
+        return self.orders.get(user_id, [])[:limit]
+    
+    async def get_preferences(self, user_id: str):
+        return self.preferences.get(user_id, {})
+
+
+# Tools that use context injection
+# Note: The first parameter must be named 'ctx' or 'context'
+
+async def get_my_orders(ctx: ToolContext, limit: int = 5) -> str:
+    """Get the current user's orders.
+    
+    Args:
+        ctx: Injected context containing 'db' and 'user_id'
+        limit: Maximum number of orders to return
+    
+    Returns:
+        JSON string of user's orders
+    """
+    import json
+    
+    db = ctx["db"]
+    user_id = ctx["user_id"]
+    
+    orders = await db.get_orders(user_id, limit)
+    
+    return json.dumps({
+        "user_id": user_id,
+        "orders": orders,
+        "count": len(orders)
+    })
+
+
+async def get_my_preferences(ctx: ToolContext) -> str:
+    """Get the current user's preferences.
+    
+    Args:
+        ctx: Injected context containing 'db' and 'user_id'
+    
+    Returns:
+        JSON string of user's preferences
+    """
+    import json
+    
+    db = ctx["db"]
+    user_id = ctx["user_id"]
+    
+    prefs = await db.get_preferences(user_id)
+    
+    return json.dumps({
+        "user_id": user_id,
+        "preferences": prefs
+    })
+
+
+def get_current_user_info(ctx: ToolContext) -> str:
+    """Get information about the current user.
+    
+    This is a sync tool example - context injection works for both
+    sync and async tools.
+    
+    Args:
+        ctx: Injected context containing user info
+    
+    Returns:
+        String describing the current user
+    """
+    user_id = ctx["user_id"]
+    user_name = ctx.get("user_name", "Unknown")
+    user_tier = ctx.get("user_tier", "standard")
+    
+    return f"Current user: {user_name} (ID: {user_id}, Tier: {user_tier})"
+
+
+# Create tool definitions
+orders_tool = {
+    "definition": {
+        "type": "function",
+        "function": {
+            "name": "get_my_orders",
+            "description": "Get the current user's order history",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum number of orders to return",
+                        "default": 5
+                    }
+                },
+                "required": []
+            }
+        }
+    },
+    "implementation": get_my_orders
+}
+
+preferences_tool = {
+    "definition": {
+        "type": "function",
+        "function": {
+            "name": "get_my_preferences",
+            "description": "Get the current user's preferences and settings",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        }
+    },
+    "implementation": get_my_preferences
+}
+
+user_info_tool = {
+    "definition": {
+        "type": "function",
+        "function": {
+            "name": "get_current_user_info",
+            "description": "Get information about the current logged-in user",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        }
+    },
+    "implementation": get_current_user_info
+}
+
+
+async def basic_context_injection():
+    """Basic example: Inject database and user info into tools."""
+    print("=" * 60)
+    print("Basic Tool Context Injection Example")
+    print("=" * 60)
+    
+    # Create agent with context-aware tools
+    agent = Agent(
+        name="account-assistant",
+        model_name="gpt-4.1",
+        purpose="To help users with their account and orders",
+        tools=[orders_tool, preferences_tool, user_info_tool]
+    )
+    
+    # Create shared database
+    db = MockDatabase()
+    
+    # Request for User A
+    print("\n--- Request from User 123 (Alice) ---")
+    
+    thread_a = Thread()
+    thread_a.add_message(Message(
+        role="user",
+        content="What are my recent orders?"
+    ))
+    
+    # Inject context for User A
+    result_a = await agent.run(
+        thread_a,
+        tool_context={
+            "db": db,
+            "user_id": "user_123",
+            "user_name": "Alice",
+            "user_tier": "premium"
+        }
+    )
+    
+    print(f"Response for Alice: {result_a.content[:200]}...")
+    
+    # Same agent, different user context
+    print("\n--- Request from User 456 (Bob) ---")
+    
+    thread_b = Thread()
+    thread_b.add_message(Message(
+        role="user",
+        content="What are my orders and preferences?"
+    ))
+    
+    # Inject context for User B
+    result_b = await agent.run(
+        thread_b,
+        tool_context={
+            "db": db,
+            "user_id": "user_456",
+            "user_name": "Bob",
+            "user_tier": "standard"
+        }
+    )
+    
+    print(f"Response for Bob: {result_b.content[:200]}...")
+
+
+async def streaming_with_context():
+    """Example: Use tool context with streaming."""
+    print("\n" + "=" * 60)
+    print("Streaming with Tool Context Example")
+    print("=" * 60)
+    
+    from tyler import EventType
+    
+    agent = Agent(
+        name="streaming-assistant",
+        model_name="gpt-4.1",
+        purpose="To help users with their account",
+        tools=[orders_tool]
+    )
+    
+    db = MockDatabase()
+    
+    thread = Thread()
+    thread.add_message(Message(
+        role="user",
+        content="Show me my orders"
+    ))
+    
+    print("\nStreaming response:")
+    
+    # Stream with tool context
+    async for event in agent.stream(
+        thread,
+        tool_context={
+            "db": db,
+            "user_id": "user_123",
+            "user_name": "Alice"
+        }
+    ):
+        if event.type == EventType.LLM_STREAM_CHUNK:
+            print(event.data.get("content_chunk", ""), end="", flush=True)
+        elif event.type == EventType.TOOL_SELECTED:
+            print(f"\n🔧 Using tool: {event.data['tool_name']}")
+        elif event.type == EventType.TOOL_RESULT:
+            print(f"   Tool returned: {event.data['result'][:100]}...")
+    
+    print()  # Final newline
+
+
+async def main():
+    """Run all examples."""
+    # Basic context injection
+    await basic_context_injection()
+    
+    # Streaming with context
+    await streaming_with_context()
+    
+    print("\n" + "=" * 60)
+    print("All examples complete!")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+

--- a/packages/tyler/tests/conftest.py
+++ b/packages/tyler/tests/conftest.py
@@ -27,24 +27,32 @@ def mock_openai():
     - litellm.completion / litellm.acompletion (direct module access)
     - tyler.models.agent.acompletion (from litellm import acompletion)
     
-    The mock detects if response_format is requested (structured output) and
-    returns valid JSON that can be parsed, otherwise returns plain text.
+    The mock detects:
+    1. If an output tool (e.g., __MovieReview_output__) is in tools, return a tool call
+    2. If response_format is requested, return valid JSON
+    3. Otherwise return plain text
     """
     from unittest.mock import AsyncMock
     import json
     
-    def create_mock_response(content):
+    def create_mock_response(content, tool_calls=None):
         return MagicMock(
-            choices=[MagicMock(message=MagicMock(content=content, tool_calls=None))],
+            choices=[MagicMock(message=MagicMock(content=content, tool_calls=tool_calls))],
             usage=MagicMock(prompt_tokens=10, completion_tokens=20, total_tokens=30)
         )
     
-    # Default response for non-structured output
-    default_response = create_mock_response("Test response")
+    def create_tool_call_response(tool_name, arguments):
+        """Create a response with a tool call."""
+        tool_call = MagicMock()
+        tool_call.id = "call_test123"
+        tool_call.type = "function"
+        tool_call.function = MagicMock()
+        tool_call.function.name = tool_name
+        tool_call.function.arguments = json.dumps(arguments)
+        return create_mock_response(None, tool_calls=[tool_call])
     
-    # JSON response for structured output - a generic object that can be parsed
-    # Real validation will fail but at least JSON parsing succeeds
-    json_response = create_mock_response(json.dumps({
+    # Generic structured output data that matches common test schemas
+    structured_data = {
         "title": "Test Movie",
         "rating": 8.5,
         "genre": "drama",
@@ -56,12 +64,31 @@ def mock_openai():
         "summary": "Test summary",
         "requires_escalation": False,
         "suggested_actions": ["Review", "Follow up"]
-    }))
+    }
+    
+    # Default response for non-structured output
+    default_response = create_mock_response("Test response")
+    
+    # JSON response for simple JSON mode (response_format="json")
+    json_response = create_mock_response(json.dumps(structured_data))
     
     def smart_response(*args, **kwargs):
-        """Return JSON for structured output requests, plain text otherwise."""
+        """Return appropriate response based on request type."""
+        tools = kwargs.get('tools', [])
+        
+        # Check for output tool pattern (structured output via tool calls)
+        for tool in tools:
+            if tool.get('type') == 'function':
+                func = tool.get('function', {})
+                name = func.get('name', '')
+                if name.startswith('__') and name.endswith('_output__'):
+                    # Return a tool call to the output tool with valid data
+                    return create_tool_call_response(name, structured_data)
+        
+        # Check for simple JSON mode
         if kwargs.get('response_format'):
             return json_response
+        
         return default_response
     
     async def async_smart_response(*args, **kwargs):

--- a/packages/tyler/tests/conftest.py
+++ b/packages/tyler/tests/conftest.py
@@ -21,12 +21,19 @@ def mock_env_vars():
 
 @pytest.fixture(autouse=True)
 def mock_openai():
-    """Mock OpenAI/litellm calls for testing"""
-    with patch('litellm.completion') as mock:
-        mock.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content="Test response"))]
-        )
-        yield mock
+    """Mock OpenAI/litellm calls for testing (both sync and async)"""
+    from unittest.mock import AsyncMock
+    
+    mock_response = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="Test response", tool_calls=None))],
+        usage=MagicMock(prompt_tokens=10, completion_tokens=20, total_tokens=30)
+    )
+    
+    with patch('litellm.completion') as mock_sync, \
+         patch('litellm.acompletion', new_callable=AsyncMock) as mock_async:
+        mock_sync.return_value = mock_response
+        mock_async.return_value = mock_response
+        yield mock_sync, mock_async
 
 @pytest.fixture(autouse=True)
 def mock_wandb():

--- a/packages/tyler/tests/integration/test_agent_delegation_integration.py
+++ b/packages/tyler/tests/integration/test_agent_delegation_integration.py
@@ -172,7 +172,7 @@ async def test_parallel_agent_delegation(mock_thread_store):
     execution_times = []
     
     # Mock tool execution to track timing
-    async def timed_tool_execution(tool_call):
+    async def timed_tool_execution(tool_call, context=None):
         """Wrapper to time tool execution"""
         start_time = datetime.now(UTC)
         
@@ -300,7 +300,7 @@ async def test_agent_delegation_error_handling(mock_thread_store):
     mock_weave_call.ui_url = "https://weave.com/123"
     
     # Mock tool execution to simulate a failure for the failing agent
-    async def mock_tool_execution(tool_call):
+    async def mock_tool_execution(tool_call, context=None):
         """Mock that simulates a failing agent"""
         if "FailingAgent" in tool_call.function.name:
             raise Exception("Simulated agent failure")

--- a/packages/tyler/tests/models/test_agent_delegation.py
+++ b/packages/tyler/tests/models/test_agent_delegation.py
@@ -188,7 +188,7 @@ async def test_agent_delegation_tool_call(mock_litellm, mock_thread_store):
         ]
         
         # Mock the tool execution
-        async def mock_tool_execution(tool_call):
+        async def mock_tool_execution(tool_call, context=None):
             """Mock the execution of the delegation tool"""
             return "Specialized task completed successfully"
         
@@ -292,7 +292,7 @@ async def test_delegation_with_context(mock_litellm, mock_thread_store):
         ]
         
         # Mock the tool execution
-        async def mock_tool_execution(tool_call):
+        async def mock_tool_execution(tool_call, context=None):
             """Mock the execution of the delegation tool"""
             return "Data processed with context successfully"
         
@@ -409,7 +409,7 @@ async def test_nested_agent_delegation(mock_litellm, mock_thread_store):
         ]
         
         # Mock the tool execution
-        async def mock_tool_execution(tool_call):
+        async def mock_tool_execution(tool_call, context=None):
             """Mock the execution of the delegation tool"""
             return "Task completed successfully"
         

--- a/packages/tyler/tests/models/test_agent_delegation.py
+++ b/packages/tyler/tests/models/test_agent_delegation.py
@@ -35,8 +35,15 @@ def mock_thread_store():
 
 @pytest.fixture
 def mock_litellm():
-    """Mock litellm to prevent real API calls"""
-    with patch('litellm.acompletion', autospec=True) as mock:
+    """Mock litellm to prevent real API calls
+    
+    Note: conftest.py already provides autouse mock for litellm.acompletion,
+    but tests can use this fixture to get a reference to configure return values.
+    We don't use autospec=True to avoid conflicts with the global mock.
+    """
+    from unittest.mock import AsyncMock
+    with patch('litellm.acompletion', new_callable=AsyncMock) as mock, \
+         patch('tyler.models.agent.acompletion', mock):
         yield mock
 
 @pytest.fixture

--- a/packages/tyler/tests/models/test_agent_streaming.py
+++ b/packages/tyler/tests/models/test_agent_streaming.py
@@ -1094,7 +1094,7 @@ async def test_stream_multiple_tool_calls():
         
         # Mock tool execution
         call_count = 0
-        async def mock_execute(tool_call):
+        async def mock_execute(tool_call, context=None):
             nonlocal call_count
             call_count += 1
             return f"Result {call_count}"

--- a/packages/tyler/tests/test_examples.py
+++ b/packages/tyler/tests/test_examples.py
@@ -27,8 +27,6 @@ SKIP_EXAMPLES = [
     "402_a2a_basic_client.py",  # Requires a running A2A server
     "403_a2a_multi_agent.py",   # Starts multiple servers
     "a2a_manual_test.py",       # Manual test script
-    "600_structured_output.py", # Makes real API calls for structured output demo
-    "601_tool_context.py",      # Makes real API calls for tool context demo
 ]
 
 

--- a/packages/tyler/tests/test_examples.py
+++ b/packages/tyler/tests/test_examples.py
@@ -27,6 +27,8 @@ SKIP_EXAMPLES = [
     "402_a2a_basic_client.py",  # Requires a running A2A server
     "403_a2a_multi_agent.py",   # Starts multiple servers
     "a2a_manual_test.py",       # Manual test script
+    "600_structured_output.py", # Makes real API calls for structured output demo
+    "601_tool_context.py",      # Makes real API calls for tool context demo
 ]
 
 

--- a/packages/tyler/tests/test_examples.py
+++ b/packages/tyler/tests/test_examples.py
@@ -27,6 +27,7 @@ SKIP_EXAMPLES = [
     "402_a2a_basic_client.py",  # Requires a running A2A server
     "403_a2a_multi_agent.py",   # Starts multiple servers
     "a2a_manual_test.py",       # Manual test script
+    "600_structured_output.py",  # Uses output-tool pattern that requires specific model behavior
 ]
 
 

--- a/packages/tyler/tests/test_examples.py
+++ b/packages/tyler/tests/test_examples.py
@@ -27,7 +27,6 @@ SKIP_EXAMPLES = [
     "402_a2a_basic_client.py",  # Requires a running A2A server
     "403_a2a_multi_agent.py",   # Starts multiple servers
     "a2a_manual_test.py",       # Manual test script
-    "600_structured_output.py",  # Uses output-tool pattern that requires specific model behavior
 ]
 
 

--- a/packages/tyler/tests/test_structured_output.py
+++ b/packages/tyler/tests/test_structured_output.py
@@ -1,0 +1,278 @@
+"""Tests for structured output feature.
+
+Tests the response_type parameter for Agent.run() that enables
+Pydantic-validated structured outputs from LLM responses.
+"""
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from pydantic import BaseModel, Field
+from typing import List, Literal, Optional
+
+from tyler import Agent, AgentResult, RetryConfig, StructuredOutputError
+from narrator import Thread, Message
+
+
+class Invoice(BaseModel):
+    """Test model for structured output."""
+    invoice_id: str
+    total: float
+    items: List[str]
+    paid: bool = False
+
+
+class SupportTicket(BaseModel):
+    """More complex test model with validation."""
+    priority: Literal["low", "medium", "high"]
+    category: str
+    summary: str = Field(max_length=500)
+    requires_escalation: bool
+
+
+class TestStructuredOutputBasic:
+    """Basic structured output tests."""
+    
+    @pytest.fixture
+    def agent(self):
+        """Create a basic agent for testing."""
+        return Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test structured output"
+        )
+    
+    @pytest.fixture
+    def thread(self):
+        """Create a test thread."""
+        t = Thread()
+        t.add_message(Message(role="user", content="Create an invoice for $100"))
+        return t
+    
+    @pytest.mark.asyncio
+    async def test_structured_output_basic(self, agent, thread):
+        """Test that structured output returns validated model."""
+        # Mock the LLM response with valid JSON
+        valid_response = {
+            "invoice_id": "INV-001",
+            "total": 100.00,
+            "items": ["Widget A", "Widget B"],
+            "paid": False
+        }
+        
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(valid_response)
+        
+        # Patch acompletion in the agent module where it's imported
+        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
+            mock_completion.return_value = mock_response
+            
+            result = await agent.run(thread, response_type=Invoice)
+            
+            # Verify structured_data is populated
+            assert result.structured_data is not None
+            assert isinstance(result.structured_data, Invoice)
+            assert result.structured_data.invoice_id == "INV-001"
+            assert result.structured_data.total == 100.00
+            assert result.structured_data.items == ["Widget A", "Widget B"]
+            assert result.structured_data.paid is False
+            
+            # Verify content is also available
+            assert result.content == json.dumps(valid_response)
+            
+            # Verify no retries were needed
+            assert result.validation_retries == 0
+    
+    @pytest.mark.asyncio
+    async def test_structured_output_disabled_by_default(self, agent, thread):
+        """Test that structured_data is None when response_type is not provided."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Here's an invoice for you..."
+        mock_response.choices[0].message.tool_calls = None
+        
+        with patch.object(agent, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.return_value = (mock_response, {"usage": {}})
+            
+            result = await agent.run(thread)
+            
+            # structured_data should be None when not using response_type
+            assert result.structured_data is None
+    
+    @pytest.mark.asyncio
+    async def test_validation_failure_raises_without_retry(self, agent, thread):
+        """Test that validation failure raises StructuredOutputError when no retry config."""
+        # Invalid response - missing required fields
+        invalid_response = {
+            "invoice_id": "INV-001"
+            # Missing: total, items
+        }
+        
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(invalid_response)
+        
+        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
+            mock_completion.return_value = mock_response
+            
+            with pytest.raises(StructuredOutputError) as exc_info:
+                await agent.run(thread, response_type=Invoice)
+            
+            # Verify error details
+            assert "Validation failed" in str(exc_info.value)
+            assert exc_info.value.validation_errors is not None
+            assert len(exc_info.value.validation_errors) > 0
+            assert exc_info.value.last_response == invalid_response
+
+
+class TestStructuredOutputRetry:
+    """Tests for retry logic on validation failure."""
+    
+    @pytest.fixture
+    def agent_with_retry(self):
+        """Create agent with retry config."""
+        return Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test structured output with retry",
+            retry_config=RetryConfig(max_retries=2, backoff_base_seconds=0.01)
+        )
+    
+    @pytest.fixture
+    def thread(self):
+        """Create a test thread."""
+        t = Thread()
+        t.add_message(Message(role="user", content="Create a support ticket"))
+        return t
+    
+    @pytest.mark.asyncio
+    async def test_retry_on_validation_failure(self, agent_with_retry, thread):
+        """Test that agent retries on validation failure and succeeds."""
+        # First response is invalid, second is valid
+        invalid_response = {"priority": "invalid_priority"}  # Not in Literal
+        valid_response = {
+            "priority": "high",
+            "category": "billing",
+            "summary": "Payment issue",
+            "requires_escalation": True
+        }
+        
+        mock_response_1 = MagicMock()
+        mock_response_1.choices = [MagicMock()]
+        mock_response_1.choices[0].message.content = json.dumps(invalid_response)
+        
+        mock_response_2 = MagicMock()
+        mock_response_2.choices = [MagicMock()]
+        mock_response_2.choices[0].message.content = json.dumps(valid_response)
+        
+        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
+            mock_completion.side_effect = [mock_response_1, mock_response_2]
+            
+            result = await agent_with_retry.run(thread, response_type=SupportTicket)
+            
+            # Should succeed after retry
+            assert result.structured_data is not None
+            assert isinstance(result.structured_data, SupportTicket)
+            assert result.structured_data.priority == "high"
+            
+            # Should have taken 1 retry
+            assert result.validation_retries == 1
+            
+            # Should have called completion twice
+            assert mock_completion.call_count == 2
+    
+    @pytest.mark.asyncio
+    async def test_max_retries_exceeded(self, agent_with_retry, thread):
+        """Test that error is raised after max retries exceeded."""
+        # All responses are invalid
+        invalid_response = {"priority": "invalid"}
+        
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = json.dumps(invalid_response)
+        
+        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
+            # Return invalid response for all attempts (initial + 2 retries = 3)
+            mock_completion.return_value = mock_response
+            
+            with pytest.raises(StructuredOutputError) as exc_info:
+                await agent_with_retry.run(thread, response_type=SupportTicket)
+            
+            # Should have tried 3 times (initial + 2 retries)
+            assert mock_completion.call_count == 3
+            assert "after 3 attempts" in str(exc_info.value)
+    
+    @pytest.mark.asyncio
+    async def test_json_parse_error_triggers_retry(self, agent_with_retry, thread):
+        """Test that JSON parse errors also trigger retry."""
+        invalid_json = "This is not valid JSON {"
+        valid_response = {
+            "priority": "low",
+            "category": "general",
+            "summary": "Test ticket",
+            "requires_escalation": False
+        }
+        
+        mock_response_1 = MagicMock()
+        mock_response_1.choices = [MagicMock()]
+        mock_response_1.choices[0].message.content = invalid_json
+        
+        mock_response_2 = MagicMock()
+        mock_response_2.choices = [MagicMock()]
+        mock_response_2.choices[0].message.content = json.dumps(valid_response)
+        
+        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
+            mock_completion.side_effect = [mock_response_1, mock_response_2]
+            
+            result = await agent_with_retry.run(thread, response_type=SupportTicket)
+            
+            # Should succeed after retry
+            assert result.structured_data is not None
+            assert result.validation_retries == 1
+
+
+class TestRetryConfig:
+    """Tests for RetryConfig model."""
+    
+    def test_default_values(self):
+        """Test RetryConfig default values."""
+        config = RetryConfig()
+        assert config.max_retries == 3
+        assert config.retry_on_validation_error is True
+        assert config.backoff_base_seconds == 0.5
+    
+    def test_custom_values(self):
+        """Test RetryConfig with custom values."""
+        config = RetryConfig(
+            max_retries=5,
+            retry_on_validation_error=False,
+            backoff_base_seconds=1.0
+        )
+        assert config.max_retries == 5
+        assert config.retry_on_validation_error is False
+        assert config.backoff_base_seconds == 1.0
+    
+    def test_max_retries_bounds(self):
+        """Test that max_retries is bounded."""
+        from pydantic import ValidationError
+        
+        # Valid bounds
+        assert RetryConfig(max_retries=0).max_retries == 0
+        assert RetryConfig(max_retries=10).max_retries == 10
+        
+        # Invalid - too high
+        with pytest.raises(ValidationError):
+            RetryConfig(max_retries=11)
+        
+        # Invalid - negative
+        with pytest.raises(ValidationError):
+            RetryConfig(max_retries=-1)
+    
+    def test_immutable(self):
+        """Test that RetryConfig is immutable (frozen)."""
+        from pydantic import ValidationError
+        
+        config = RetryConfig()
+        with pytest.raises(ValidationError):
+            config.max_retries = 5
+

--- a/packages/tyler/tests/test_structured_output.py
+++ b/packages/tyler/tests/test_structured_output.py
@@ -534,10 +534,14 @@ class TestStructuredOutputValidation:
             # Should succeed on second attempt
             assert result.structured_data is not None
             
-            # Check that a reminder message was added
-            reminder_messages = [m for m in thread.messages if m.role == "user" and "must provide your response" in m.content]
+            # Check that a system reminder message was added
+            reminder_messages = [m for m in thread.messages if m.role == "system" and "must provide your response" in m.content]
             assert len(reminder_messages) == 1
             assert "__Invoice_output__" in reminder_messages[0].content
+            # Verify the source identifies it as an agent-generated reminder
+            assert reminder_messages[0].source["type"] == "agent"
+            assert reminder_messages[0].source["name"] == "structured_output_reminder"
+            assert reminder_messages[0].source["id"] == "test-agent"
     
     @pytest.mark.asyncio
     async def test_regular_tools_processed_before_output_tool(self, thread):

--- a/packages/tyler/tests/test_structured_output.py
+++ b/packages/tyler/tests/test_structured_output.py
@@ -2,6 +2,10 @@
 
 Tests the response_type parameter for Agent.run() that enables
 Pydantic-validated structured outputs from LLM responses.
+
+The implementation uses an output-tool pattern where the structured
+output schema is registered as a special tool that the model calls
+when ready to provide its final answer.
 """
 import pytest
 import json
@@ -29,6 +33,34 @@ class SupportTicket(BaseModel):
     requires_escalation: bool
 
 
+def create_output_tool_response(model_name: str, data: dict, content: str = ""):
+    """Helper to create a mock response with output tool call."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = content
+    
+    # Create tool call for the output tool
+    tool_call = MagicMock()
+    tool_call.id = "call_123"
+    tool_call.type = "function"
+    tool_call.function = MagicMock()
+    tool_call.function.name = f"__{model_name}_output__"
+    tool_call.function.arguments = json.dumps(data)
+    
+    mock_response.choices[0].message.tool_calls = [tool_call]
+    
+    return mock_response
+
+
+def create_plain_response(content: str):
+    """Helper to create a mock response with plain text (no tool calls)."""
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = content
+    mock_response.choices[0].message.tool_calls = None
+    return mock_response
+
+
 class TestStructuredOutputBasic:
     """Basic structured output tests."""
     
@@ -50,22 +82,18 @@ class TestStructuredOutputBasic:
     
     @pytest.mark.asyncio
     async def test_structured_output_basic(self, agent, thread):
-        """Test that structured output returns validated model."""
-        # Mock the LLM response with valid JSON
-        valid_response = {
+        """Test that structured output returns validated model via output tool."""
+        valid_data = {
             "invoice_id": "INV-001",
             "total": 100.00,
             "items": ["Widget A", "Widget B"],
             "paid": False
         }
         
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = json.dumps(valid_response)
+        mock_response = create_output_tool_response("Invoice", valid_data)
         
-        # Patch acompletion in the agent module where it's imported
-        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
-            mock_completion.return_value = mock_response
+        with patch.object(agent, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.return_value = (mock_response, {"usage": {}})
             
             result = await agent.run(thread, response_type=Invoice)
             
@@ -77,8 +105,8 @@ class TestStructuredOutputBasic:
             assert result.structured_data.items == ["Widget A", "Widget B"]
             assert result.structured_data.paid is False
             
-            # Verify content is also available
-            assert result.content == json.dumps(valid_response)
+            # Verify content contains the JSON
+            assert json.loads(result.content) == valid_data
             
             # Verify no retries were needed
             assert result.validation_retries == 0
@@ -86,10 +114,7 @@ class TestStructuredOutputBasic:
     @pytest.mark.asyncio
     async def test_structured_output_disabled_by_default(self, agent, thread):
         """Test that structured_data is None when response_type is not provided."""
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = "Here's an invoice for you..."
-        mock_response.choices[0].message.tool_calls = None
+        mock_response = create_plain_response("Here's an invoice for you...")
         
         with patch.object(agent, 'step', new_callable=AsyncMock) as mock_step:
             mock_step.return_value = (mock_response, {"usage": {}})
@@ -102,29 +127,25 @@ class TestStructuredOutputBasic:
     @pytest.mark.asyncio
     async def test_agent_level_response_type(self, thread):
         """Test that response_type on Agent is used as default for all runs."""
-        # Create agent with default response_type
         agent_with_default = Agent(
             name="test-agent",
             model_name="gpt-4.1",
             purpose="Test structured output",
-            response_type=Invoice  # Agent-level default
+            response_type=Invoice
         )
         
-        valid_response = {
+        valid_data = {
             "invoice_id": "INV-002",
             "total": 250.00,
             "items": ["Service A"],
             "paid": True
         }
         
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = json.dumps(valid_response)
+        mock_response = create_output_tool_response("Invoice", valid_data)
         
-        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
-            mock_completion.return_value = mock_response
+        with patch.object(agent_with_default, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.return_value = (mock_response, {"usage": {}})
             
-            # No response_type passed - should use agent's default
             result = await agent_with_default.run(thread)
             
             assert result.structured_data is not None
@@ -134,7 +155,6 @@ class TestStructuredOutputBasic:
     @pytest.mark.asyncio
     async def test_per_run_response_type_overrides_agent_default(self, thread):
         """Test that per-run response_type overrides agent's default."""
-        # Create agent with Invoice as default
         agent_with_default = Agent(
             name="test-agent",
             model_name="gpt-4.1",
@@ -142,25 +162,21 @@ class TestStructuredOutputBasic:
             response_type=Invoice
         )
         
-        # Response that matches SupportTicket, not Invoice
-        support_response = {
+        support_data = {
             "priority": "high",
             "category": "billing",
             "summary": "Payment issue",
             "requires_escalation": True
         }
         
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = json.dumps(support_response)
+        # Note: output tool name changes based on the response_type passed to run()
+        mock_response = create_output_tool_response("SupportTicket", support_data)
         
-        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
-            mock_completion.return_value = mock_response
+        with patch.object(agent_with_default, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.return_value = (mock_response, {"usage": {}})
             
-            # Override with SupportTicket for this run
             result = await agent_with_default.run(thread, response_type=SupportTicket)
             
-            # Should be SupportTicket, not Invoice
             assert result.structured_data is not None
             assert isinstance(result.structured_data, SupportTicket)
             assert result.structured_data.priority == "high"
@@ -169,17 +185,15 @@ class TestStructuredOutputBasic:
     async def test_validation_failure_raises_without_retry(self, agent, thread):
         """Test that validation failure raises StructuredOutputError when no retry config."""
         # Invalid response - missing required fields
-        invalid_response = {
+        invalid_data = {
             "invoice_id": "INV-001"
             # Missing: total, items
         }
         
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = json.dumps(invalid_response)
+        mock_response = create_output_tool_response("Invoice", invalid_data)
         
-        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
-            mock_completion.return_value = mock_response
+        with patch.object(agent, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.return_value = (mock_response, {"usage": {}})
             
             with pytest.raises(StructuredOutputError) as exc_info:
                 await agent.run(thread, response_type=Invoice)
@@ -188,7 +202,7 @@ class TestStructuredOutputBasic:
             assert "Validation failed" in str(exc_info.value)
             assert exc_info.value.validation_errors is not None
             assert len(exc_info.value.validation_errors) > 0
-            assert exc_info.value.last_response == invalid_response
+            assert exc_info.value.last_response == invalid_data
 
 
 class TestStructuredOutputRetry:
@@ -215,24 +229,22 @@ class TestStructuredOutputRetry:
     async def test_retry_on_validation_failure(self, agent_with_retry, thread):
         """Test that agent retries on validation failure and succeeds."""
         # First response is invalid, second is valid
-        invalid_response = {"priority": "invalid_priority"}  # Not in Literal
-        valid_response = {
+        invalid_data = {"priority": "invalid_priority"}  # Not in Literal
+        valid_data = {
             "priority": "high",
             "category": "billing",
             "summary": "Payment issue",
             "requires_escalation": True
         }
         
-        mock_response_1 = MagicMock()
-        mock_response_1.choices = [MagicMock()]
-        mock_response_1.choices[0].message.content = json.dumps(invalid_response)
+        mock_response_1 = create_output_tool_response("SupportTicket", invalid_data)
+        mock_response_2 = create_output_tool_response("SupportTicket", valid_data)
         
-        mock_response_2 = MagicMock()
-        mock_response_2.choices = [MagicMock()]
-        mock_response_2.choices[0].message.content = json.dumps(valid_response)
-        
-        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
-            mock_completion.side_effect = [mock_response_1, mock_response_2]
+        with patch.object(agent_with_retry, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.side_effect = [
+                (mock_response_1, {"usage": {}}),
+                (mock_response_2, {"usage": {}})
+            ]
             
             result = await agent_with_retry.run(thread, response_type=SupportTicket)
             
@@ -244,57 +256,358 @@ class TestStructuredOutputRetry:
             # Should have taken 1 retry
             assert result.validation_retries == 1
             
-            # Should have called completion twice
-            assert mock_completion.call_count == 2
+            # Should have called step twice
+            assert mock_step.call_count == 2
     
     @pytest.mark.asyncio
     async def test_max_retries_exceeded(self, agent_with_retry, thread):
         """Test that error is raised after max retries exceeded."""
         # All responses are invalid
-        invalid_response = {"priority": "invalid"}
+        invalid_data = {"priority": "invalid"}
         
-        mock_response = MagicMock()
-        mock_response.choices = [MagicMock()]
-        mock_response.choices[0].message.content = json.dumps(invalid_response)
+        mock_response = create_output_tool_response("SupportTicket", invalid_data)
         
-        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
+        with patch.object(agent_with_retry, 'step', new_callable=AsyncMock) as mock_step:
             # Return invalid response for all attempts (initial + 2 retries = 3)
-            mock_completion.return_value = mock_response
+            mock_step.return_value = (mock_response, {"usage": {}})
             
             with pytest.raises(StructuredOutputError) as exc_info:
                 await agent_with_retry.run(thread, response_type=SupportTicket)
             
             # Should have tried 3 times (initial + 2 retries)
-            assert mock_completion.call_count == 3
+            assert mock_step.call_count == 3
             assert "after 3 attempts" in str(exc_info.value)
     
     @pytest.mark.asyncio
     async def test_json_parse_error_triggers_retry(self, agent_with_retry, thread):
         """Test that JSON parse errors also trigger retry."""
-        invalid_json = "This is not valid JSON {"
-        valid_response = {
+        # Create a response with invalid JSON in tool arguments
+        mock_response_1 = MagicMock()
+        mock_response_1.choices = [MagicMock()]
+        mock_response_1.choices[0].message.content = ""
+        tool_call_1 = MagicMock()
+        tool_call_1.id = "call_123"
+        tool_call_1.type = "function"
+        tool_call_1.function = MagicMock()
+        tool_call_1.function.name = "__SupportTicket_output__"
+        tool_call_1.function.arguments = "This is not valid JSON {"
+        mock_response_1.choices[0].message.tool_calls = [tool_call_1]
+        
+        valid_data = {
             "priority": "low",
             "category": "general",
             "summary": "Test ticket",
             "requires_escalation": False
         }
+        mock_response_2 = create_output_tool_response("SupportTicket", valid_data)
         
-        mock_response_1 = MagicMock()
-        mock_response_1.choices = [MagicMock()]
-        mock_response_1.choices[0].message.content = invalid_json
-        
-        mock_response_2 = MagicMock()
-        mock_response_2.choices = [MagicMock()]
-        mock_response_2.choices[0].message.content = json.dumps(valid_response)
-        
-        with patch('tyler.models.agent.acompletion', new_callable=AsyncMock) as mock_completion:
-            mock_completion.side_effect = [mock_response_1, mock_response_2]
+        with patch.object(agent_with_retry, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.side_effect = [
+                (mock_response_1, {"usage": {}}),
+                (mock_response_2, {"usage": {}})
+            ]
             
             result = await agent_with_retry.run(thread, response_type=SupportTicket)
             
             # Should succeed after retry
             assert result.structured_data is not None
             assert result.validation_retries == 1
+
+
+class TestResponseFormatJson:
+    """Tests for response_format='json' simple JSON mode."""
+    
+    @pytest.fixture
+    def agent(self):
+        """Create a basic agent for testing."""
+        return Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test JSON mode"
+        )
+    
+    @pytest.fixture
+    def thread(self):
+        """Create a test thread."""
+        t = Thread()
+        t.add_message(Message(role="user", content="Give me some data"))
+        return t
+    
+    @pytest.mark.asyncio
+    async def test_response_format_json_passes_to_completion(self, agent, thread):
+        """Test that response_format='json' adds json_object to completion params."""
+        mock_response = create_plain_response('{"key": "value"}')
+        
+        captured_params = {}
+        
+        async def capture_step(thread_arg, stream=False):
+            # Check that _response_format is set
+            captured_params['response_format'] = agent._response_format
+            return (mock_response, {"usage": {}})
+        
+        with patch.object(agent, 'step', side_effect=capture_step):
+            result = await agent.run(thread, response_format="json")
+            
+            # Verify response_format was set during run
+            assert captured_params.get('response_format') == "json"
+            
+            # Should return the JSON content
+            assert result.content == '{"key": "value"}'
+            
+            # structured_data should be None (response_format doesn't validate)
+            assert result.structured_data is None
+
+
+class TestStructuredOutputWithTools:
+    """Tests for structured output working with regular tools."""
+    
+    @pytest.fixture
+    def thread(self):
+        """Create a test thread."""
+        t = Thread()
+        t.add_message(Message(role="user", content="Search for invoices"))
+        return t
+    
+    @pytest.mark.asyncio
+    async def test_regular_tool_call_before_output_tool(self, thread):
+        """Test that regular tools can be called before the output tool."""
+        # Create agent without tools - we'll add a mock tool definition manually
+        agent = Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test with tools"
+        )
+        
+        # Add a mock tool to processed_tools
+        mock_tool_def = {
+            "type": "function",
+            "function": {
+                "name": "get_current_time",
+                "description": "Get current time",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        }
+        agent._processed_tools = [mock_tool_def]
+        
+        # First response: model calls a regular tool
+        tool_call_response = MagicMock()
+        tool_call_response.choices = [MagicMock()]
+        tool_call_response.choices[0].message.content = "Let me check the time first"
+        tool_call = MagicMock()
+        tool_call.id = "call_time"
+        tool_call.type = "function"
+        tool_call.function = MagicMock()
+        tool_call.function.name = "get_current_time"
+        tool_call.function.arguments = "{}"
+        tool_call_response.choices[0].message.tool_calls = [tool_call]
+        
+        # Second response: model calls the output tool
+        valid_data = {
+            "invoice_id": "INV-001",
+            "total": 100.00,
+            "items": ["Time-based billing"],
+            "paid": False
+        }
+        output_response = create_output_tool_response("Invoice", valid_data)
+        
+        with patch.object(agent, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.side_effect = [
+                (tool_call_response, {"usage": {}}),
+                (output_response, {"usage": {}})
+            ]
+            
+            # Mock tool execution
+            with patch.object(agent, '_handle_tool_execution', new_callable=AsyncMock) as mock_tool:
+                mock_tool.return_value = "Current time: 2024-01-15 10:30:00"
+                
+                result = await agent.run(thread, response_type=Invoice)
+                
+                # Should succeed with structured output
+                assert result.structured_data is not None
+                assert isinstance(result.structured_data, Invoice)
+                assert result.structured_data.invoice_id == "INV-001"
+                
+                # Regular tool should have been called
+                assert mock_tool.called
+    
+    @pytest.mark.asyncio
+    async def test_output_tool_passed_to_step(self, thread):
+        """Test that the output tool is passed to step() as a parameter."""
+        agent = Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test output tool addition"
+        )
+        
+        valid_data = {"invoice_id": "INV-001", "total": 50.0, "items": ["Test"], "paid": True}
+        output_response = create_output_tool_response("Invoice", valid_data)
+        
+        captured_tools = []
+        captured_system_prompt = []
+        
+        async def capture_step(thread_arg, stream=False, tools=None, system_prompt=None):
+            # Capture the tools passed to step
+            if tools:
+                captured_tools.extend(tools)
+            if system_prompt:
+                captured_system_prompt.append(system_prompt)
+            return (output_response, {"usage": {}})
+        
+        with patch.object(agent, 'step', side_effect=capture_step):
+            await agent.run(thread, response_type=Invoice)
+            
+            # Check that output tool was passed to step
+            output_tool_names = [t.get('function', {}).get('name', '') for t in captured_tools]
+            assert "__Invoice_output__" in output_tool_names
+            
+            # Check that system prompt includes output instruction
+            assert len(captured_system_prompt) > 0
+            assert "structured_output_instruction" in captured_system_prompt[0]
+
+
+class TestStructuredOutputValidation:
+    """Tests for validation and edge cases."""
+    
+    @pytest.fixture
+    def thread(self):
+        """Create a test thread."""
+        t = Thread()
+        t.add_message(Message(role="user", content="Test"))
+        return t
+    
+    @pytest.mark.asyncio
+    async def test_response_type_and_response_format_conflict(self, thread):
+        """Test that using both response_type and response_format raises an error."""
+        agent = Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test validation"
+        )
+        
+        with pytest.raises(ValueError) as exc_info:
+            await agent.run(thread, response_type=Invoice, response_format="json")
+        
+        assert "Cannot specify both response_type and response_format" in str(exc_info.value)
+    
+    @pytest.mark.asyncio
+    async def test_agent_level_response_type_and_response_format_conflict(self, thread):
+        """Test that agent-level response_type conflicts with response_format."""
+        agent = Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test validation",
+            response_type=Invoice  # Agent-level default
+        )
+        
+        with pytest.raises(ValueError) as exc_info:
+            await agent.run(thread, response_format="json")
+        
+        assert "Cannot specify both response_type and response_format" in str(exc_info.value)
+    
+    @pytest.mark.asyncio
+    async def test_plain_text_response_triggers_reminder(self, thread):
+        """Test that plain text response adds a reminder message."""
+        agent = Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test reminder"
+        )
+        
+        # First response: plain text (no tool calls)
+        plain_text_response = create_plain_response("Here is my answer...")
+        
+        # Second response: proper output tool call
+        valid_data = {"invoice_id": "INV-001", "total": 50.0, "items": ["Test"], "paid": True}
+        output_response = create_output_tool_response("Invoice", valid_data)
+        
+        call_count = [0]
+        
+        async def mock_step(thread_arg, stream=False, tools=None, system_prompt=None):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return (plain_text_response, {"usage": {}})
+            return (output_response, {"usage": {}})
+        
+        with patch.object(agent, 'step', side_effect=mock_step):
+            result = await agent.run(thread, response_type=Invoice)
+            
+            # Should succeed on second attempt
+            assert result.structured_data is not None
+            
+            # Check that a reminder message was added
+            reminder_messages = [m for m in thread.messages if m.role == "user" and "must provide your response" in m.content]
+            assert len(reminder_messages) == 1
+            assert "__Invoice_output__" in reminder_messages[0].content
+    
+    @pytest.mark.asyncio
+    async def test_regular_tools_processed_before_output_tool(self, thread):
+        """Test that regular tool calls are processed before the output tool."""
+        agent = Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test tool ordering"
+        )
+        
+        # Add a mock tool definition
+        mock_tool_def = {
+            "type": "function",
+            "function": {
+                "name": "fetch_data",
+                "description": "Fetch data",
+                "parameters": {"type": "object", "properties": {}}
+            }
+        }
+        agent._processed_tools = [mock_tool_def]
+        
+        # Response with both a regular tool call AND output tool call
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        
+        # Regular tool call
+        regular_tool_call = MagicMock()
+        regular_tool_call.id = "call_regular"
+        regular_tool_call.type = "function"
+        regular_tool_call.function = MagicMock()
+        regular_tool_call.function.name = "fetch_data"
+        regular_tool_call.function.arguments = "{}"
+        
+        # Output tool call
+        output_tool_call = MagicMock()
+        output_tool_call.id = "call_output"
+        output_tool_call.type = "function"
+        output_tool_call.function = MagicMock()
+        output_tool_call.function.name = "__Invoice_output__"
+        output_tool_call.function.arguments = json.dumps({
+            "invoice_id": "INV-001", "total": 50.0, "items": ["Test"], "paid": True
+        })
+        
+        mock_response.choices[0].message.tool_calls = [regular_tool_call, output_tool_call]
+        
+        execution_order = []
+        
+        async def mock_handle_tool(tool_call):
+            tool_name = tool_call.function.name if hasattr(tool_call, 'function') else tool_call['function']['name']
+            execution_order.append(tool_name)
+            return "Success"
+        
+        def mock_process_result(result, tool_call, tool_name):
+            msg = Message(role="tool", name=tool_name, content=str(result), tool_call_id="test")
+            return msg, False
+        
+        with patch.object(agent, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.return_value = (mock_response, {"usage": {}})
+            
+            with patch.object(agent, '_handle_tool_execution', side_effect=mock_handle_tool):
+                with patch.object(agent, '_process_tool_result', side_effect=mock_process_result):
+                    result = await agent.run(thread, response_type=Invoice)
+                    
+                    # Regular tool should be processed first
+                    assert execution_order == ["fetch_data"]
+                    
+                    # Output should still be returned
+                    assert result.structured_data is not None
+                    assert result.structured_data.invoice_id == "INV-001"
 
 
 class TestRetryConfig:

--- a/packages/tyler/tests/test_tool_context.py
+++ b/packages/tyler/tests/test_tool_context.py
@@ -1,0 +1,306 @@
+"""Tests for tool context injection feature.
+
+Tests the tool_context parameter for Agent.run() and Agent.stream()
+that enables dependency injection into tools.
+"""
+import pytest
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from typing import Dict, Any
+
+from tyler import Agent, ToolContextError
+from tyler.utils.tool_runner import ToolRunner, ToolContext
+from narrator import Thread, Message
+
+
+class TestToolContextInjection:
+    """Tests for context injection into tools."""
+    
+    @pytest.fixture
+    def tool_runner(self):
+        """Create a fresh ToolRunner for testing."""
+        return ToolRunner()
+    
+    def test_tool_expects_context_with_ctx_param(self, tool_runner):
+        """Test detection of tools that expect context via 'ctx' parameter."""
+        async def tool_with_ctx(ctx: ToolContext, query: str) -> str:
+            return f"Query: {query}, User: {ctx.get('user_id')}"
+        
+        assert tool_runner._tool_expects_context(tool_with_ctx) is True
+    
+    def test_tool_expects_context_with_context_param(self, tool_runner):
+        """Test detection of tools that expect context via 'context' parameter."""
+        async def tool_with_context(context: Dict[str, Any], data: str) -> str:
+            return f"Data: {data}"
+        
+        assert tool_runner._tool_expects_context(tool_with_context) is True
+    
+    def test_tool_does_not_expect_context(self, tool_runner):
+        """Test that tools without ctx/context don't expect context."""
+        async def regular_tool(query: str, limit: int = 10) -> str:
+            return f"Query: {query}, Limit: {limit}"
+        
+        assert tool_runner._tool_expects_context(regular_tool) is False
+    
+    def test_tool_no_params_does_not_expect_context(self, tool_runner):
+        """Test that tools with no params don't expect context."""
+        async def no_param_tool() -> str:
+            return "No params"
+        
+        assert tool_runner._tool_expects_context(no_param_tool) is False
+    
+    @pytest.mark.asyncio
+    async def test_context_injection_async_tool(self, tool_runner):
+        """Test context is injected into async tools."""
+        received_context = {}
+        
+        async def async_tool_with_ctx(ctx: ToolContext, value: str) -> str:
+            received_context.update(ctx)
+            return f"Received: {value}"
+        
+        # Register the tool
+        tool_runner.register_tool(
+            name="test_tool",
+            implementation=async_tool_with_ctx,
+            definition={"name": "test_tool", "parameters": {"type": "object"}}
+        )
+        
+        # Call with context
+        context = {"user_id": "user_123", "db": "mock_db"}
+        result = await tool_runner.run_tool_async(
+            "test_tool", 
+            {"value": "hello"},
+            context=context
+        )
+        
+        assert result == "Received: hello"
+        assert received_context == context
+    
+    @pytest.mark.asyncio
+    async def test_context_injection_sync_tool(self, tool_runner):
+        """Test context is injected into sync tools (run in thread pool)."""
+        received_context = {}
+        
+        def sync_tool_with_ctx(ctx: ToolContext, value: str) -> str:
+            received_context.update(ctx)
+            return f"Sync received: {value}"
+        
+        # Register the tool
+        tool_runner.register_tool(
+            name="sync_tool",
+            implementation=sync_tool_with_ctx,
+            definition={"name": "sync_tool", "parameters": {"type": "object"}}
+        )
+        
+        context = {"setting": "value"}
+        result = await tool_runner.run_tool_async(
+            "sync_tool",
+            {"value": "world"},
+            context=context
+        )
+        
+        assert result == "Sync received: world"
+        assert received_context == context
+    
+    @pytest.mark.asyncio
+    async def test_missing_context_raises_error(self, tool_runner):
+        """Test that ToolContextError is raised when context is required but not provided."""
+        async def tool_requiring_ctx(ctx: ToolContext) -> str:
+            return "Should not reach here"
+        
+        tool_runner.register_tool(
+            name="ctx_tool",
+            implementation=tool_requiring_ctx,
+            definition={"name": "ctx_tool", "parameters": {"type": "object"}}
+        )
+        
+        with pytest.raises(ToolContextError) as exc_info:
+            await tool_runner.run_tool_async("ctx_tool", {}, context=None)
+        
+        assert "requires context" in str(exc_info.value)
+        assert "ctx_tool" in str(exc_info.value)
+    
+    @pytest.mark.asyncio
+    async def test_tool_without_context_ignores_provided_context(self, tool_runner):
+        """Test that tools without ctx param work when context is provided."""
+        async def regular_tool(query: str) -> str:
+            return f"Query: {query}"
+        
+        tool_runner.register_tool(
+            name="regular",
+            implementation=regular_tool,
+            definition={"name": "regular", "parameters": {"type": "object"}}
+        )
+        
+        # Should work fine - context is ignored for this tool
+        result = await tool_runner.run_tool_async(
+            "regular",
+            {"query": "test"},
+            context={"ignored": "data"}
+        )
+        
+        assert result == "Query: test"
+    
+    @pytest.mark.asyncio
+    async def test_tool_without_context_works_without_context(self, tool_runner):
+        """Test backward compatibility - tools without ctx work without context."""
+        async def regular_tool(query: str) -> str:
+            return f"Query: {query}"
+        
+        tool_runner.register_tool(
+            name="regular",
+            implementation=regular_tool,
+            definition={"name": "regular", "parameters": {"type": "object"}}
+        )
+        
+        # Should work with context=None (default)
+        result = await tool_runner.run_tool_async(
+            "regular",
+            {"query": "test"},
+            context=None
+        )
+        
+        assert result == "Query: test"
+
+
+class TestAgentToolContext:
+    """Tests for tool context in Agent.run() and Agent.stream()."""
+    
+    @pytest.fixture
+    def agent(self):
+        """Create agent with a tool that requires context."""
+        return Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test tool context"
+        )
+    
+    @pytest.fixture
+    def thread(self):
+        """Create a test thread."""
+        t = Thread()
+        t.add_message(Message(role="user", content="Get my orders"))
+        return t
+    
+    @pytest.mark.asyncio
+    async def test_tool_context_passed_through_run(self, agent, thread):
+        """Test that tool_context is available during agent.run()."""
+        # We'll verify that _tool_context is set during execution
+        captured_context = {}
+        
+        original_handle = agent._handle_tool_execution
+        
+        async def mock_handle(tool_call):
+            captured_context['ctx'] = agent._tool_context
+            return "Tool result"
+        
+        agent._handle_tool_execution = mock_handle
+        
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Let me check your orders"
+        mock_response.choices[0].message.tool_calls = None
+        
+        with patch.object(agent, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.return_value = (mock_response, {"usage": {}})
+            
+            context = {"user_id": "123", "db": "mock"}
+            await agent.run(thread, tool_context=context)
+            
+            # Context should be cleared after run completes
+            assert agent._tool_context is None
+    
+    @pytest.mark.asyncio
+    async def test_tool_context_cleared_after_run(self, agent, thread):
+        """Test that tool_context is cleared after run() completes."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = "Done"
+        mock_response.choices[0].message.tool_calls = None
+        
+        with patch.object(agent, 'step', new_callable=AsyncMock) as mock_step:
+            mock_step.return_value = (mock_response, {"usage": {}})
+            
+            await agent.run(thread, tool_context={"key": "value"})
+            
+            # Should be None after execution
+            assert agent._tool_context is None
+    
+    @pytest.mark.asyncio
+    async def test_tool_context_cleared_on_error(self, agent, thread):
+        """Test that tool_context is cleared even if run() raises."""
+        with patch.object(agent, '_run_complete', new_callable=AsyncMock) as mock_run:
+            mock_run.side_effect = RuntimeError("Test error")
+            
+            with pytest.raises(RuntimeError):
+                await agent.run(thread, tool_context={"key": "value"})
+            
+            # Should still be cleared after error
+            assert agent._tool_context is None
+
+
+class TestExecuteToolCallContext:
+    """Tests for execute_tool_call with context."""
+    
+    @pytest.fixture
+    def tool_runner(self):
+        """Create a ToolRunner with registered tools."""
+        runner = ToolRunner()
+        
+        async def tool_with_ctx(ctx: ToolContext, query: str) -> str:
+            return f"User {ctx['user_id']} queried: {query}"
+        
+        async def tool_without_ctx(query: str) -> str:
+            return f"Queried: {query}"
+        
+        runner.register_tool(
+            "with_ctx",
+            tool_with_ctx,
+            {"name": "with_ctx", "parameters": {"type": "object"}}
+        )
+        runner.register_tool(
+            "without_ctx", 
+            tool_without_ctx,
+            {"name": "without_ctx", "parameters": {"type": "object"}}
+        )
+        
+        return runner
+    
+    @pytest.mark.asyncio
+    async def test_execute_tool_call_with_context(self, tool_runner):
+        """Test execute_tool_call passes context correctly."""
+        # Create mock tool_call object
+        mock_tool_call = MagicMock()
+        mock_tool_call.function.name = "with_ctx"
+        mock_tool_call.function.arguments = json.dumps({"query": "test"})
+        
+        context = {"user_id": "user_456"}
+        result = await tool_runner.execute_tool_call(mock_tool_call, context=context)
+        
+        assert result == "User user_456 queried: test"
+    
+    @pytest.mark.asyncio
+    async def test_execute_tool_call_without_context_tool(self, tool_runner):
+        """Test execute_tool_call works for tools that don't need context."""
+        mock_tool_call = MagicMock()
+        mock_tool_call.function.name = "without_ctx"
+        mock_tool_call.function.arguments = json.dumps({"query": "hello"})
+        
+        # Context is provided but tool doesn't use it
+        result = await tool_runner.execute_tool_call(
+            mock_tool_call, 
+            context={"ignored": "data"}
+        )
+        
+        assert result == "Queried: hello"
+    
+    @pytest.mark.asyncio
+    async def test_execute_tool_call_missing_required_context(self, tool_runner):
+        """Test execute_tool_call raises when context is needed but missing."""
+        mock_tool_call = MagicMock()
+        mock_tool_call.function.name = "with_ctx"
+        mock_tool_call.function.arguments = json.dumps({"query": "test"})
+        
+        with pytest.raises(ToolContextError):
+            await tool_runner.execute_tool_call(mock_tool_call, context=None)
+

--- a/packages/tyler/tests/test_tool_context.py
+++ b/packages/tyler/tests/test_tool_context.py
@@ -190,7 +190,7 @@ class TestAgentToolContext:
         
         original_handle = agent._handle_tool_execution
         
-        async def mock_handle(tool_call):
+        async def mock_handle(tool_call, context=None):
             captured_context['ctx'] = agent._tool_context
             return "Tool result"
         

--- a/packages/tyler/tyler/__init__.py
+++ b/packages/tyler/tyler/__init__.py
@@ -8,8 +8,12 @@ from tyler.config import load_config
 from tyler.models.execution import (
     AgentResult,
     ExecutionEvent,
-    EventType
+    EventType,
+    StructuredOutputError,
+    ToolContextError
 )
+from tyler.models.retry_config import RetryConfig
+from tyler.utils.tool_runner import ToolContext
 from narrator import Thread, Message, ThreadStore, FileStore, Attachment
 
 # Configure logging when package is imported

--- a/packages/tyler/tyler/models/execution.py
+++ b/packages/tyler/tyler/models/execution.py
@@ -93,6 +93,7 @@ class StructuredOutputError(Exception):
         last_response: Optional[Any] = None
     ):
         super().__init__(message)
+        self.message = message
         self.validation_errors = validation_errors or []
         self.last_response = last_response
 

--- a/packages/tyler/tyler/models/execution.py
+++ b/packages/tyler/tyler/models/execution.py
@@ -57,12 +57,16 @@ class AgentResult:
             Only populated when agent.run() is called with a response_type parameter.
         validation_retries: Number of validation retry attempts needed.
             Only relevant when using structured output with retry_config.
+        retry_history: Detailed history of validation retry attempts.
+            Each entry contains: attempt number, validation errors, and response preview.
+            Only populated when validation retries occur during structured output.
     """
     thread: Thread
     new_messages: List[Message]
     content: Optional[str]
     structured_data: Optional[Any] = None  # Optional[BaseModel] at runtime
     validation_retries: int = 0
+    retry_history: Optional[List[Dict[str, Any]]] = None
 
 
 class StructuredOutputError(Exception):

--- a/packages/tyler/tyler/models/retry_config.py
+++ b/packages/tyler/tyler/models/retry_config.py
@@ -1,0 +1,56 @@
+"""Retry configuration for structured output validation."""
+from pydantic import BaseModel, Field
+
+
+class RetryConfig(BaseModel):
+    """Configuration for structured output validation retry.
+    
+    When using structured outputs with `response_type`, validation failures
+    can be automatically retried with error feedback sent back to the LLM.
+    
+    Example:
+        ```python
+        from tyler import Agent, RetryConfig
+        from pydantic import BaseModel
+        
+        class Invoice(BaseModel):
+            total: float
+            items: list[str]
+        
+        agent = Agent(
+            name="extractor",
+            model_name="gpt-4.1",
+            retry_config=RetryConfig(max_retries=3)
+        )
+        
+        result = await agent.run(thread, response_type=Invoice)
+        ```
+    
+    Attributes:
+        max_retries: Maximum number of retry attempts on validation failure.
+            Set to 0 to disable retry (fail immediately on first validation error).
+        retry_on_validation_error: Whether to retry when Pydantic validation fails.
+            If False, validation errors raise immediately without retry.
+        backoff_base_seconds: Base delay between retries. Actual delay is
+            `backoff_base_seconds * attempt_number` (linear backoff).
+    """
+    max_retries: int = Field(
+        default=3, 
+        ge=0, 
+        le=10,
+        description="Maximum retry attempts on validation failure (0-10)"
+    )
+    retry_on_validation_error: bool = Field(
+        default=True,
+        description="Whether to retry on Pydantic validation errors"
+    )
+    backoff_base_seconds: float = Field(
+        default=0.5, 
+        ge=0,
+        description="Base delay between retries in seconds"
+    )
+    
+    model_config = {
+        "frozen": True  # Immutable once created
+    }
+

--- a/packages/tyler/tyler/utils/tool_runner.py
+++ b/packages/tyler/tyler/utils/tool_runner.py
@@ -9,12 +9,16 @@ import json
 import asyncio
 from functools import wraps
 from tyler.utils.logging import get_logger
+from tyler.models.execution import ToolContextError
 # Direct import
 from narrator import Attachment
 import base64
 
 # Get configured logger
 logger = get_logger(__name__)
+
+# Type alias for tool context
+ToolContext = Dict[str, Any]
 
 class ToolRunner:
     def __init__(self):
@@ -96,19 +100,31 @@ class ToolRunner:
             raise ValueError(f"Error executing tool '{tool_name}': {str(e)}")
 
     @weave.op()
-    async def run_tool_async(self, tool_name: str, parameters: Dict[str, Any]) -> Any:
+    async def run_tool_async(
+        self, 
+        tool_name: str, 
+        parameters: Dict[str, Any],
+        context: Optional[ToolContext] = None
+    ) -> Any:
         """
         Executes an async tool by name with the given parameters.
+        
+        Supports optional context injection for tools that declare a 'ctx' or 'context'
+        parameter as their first argument.
         
         Args:
             tool_name: Name of the tool to execute
             parameters: Dictionary of parameters to pass to the tool
+            context: Optional context dictionary to inject into tools that expect it.
+                Tools that have 'ctx' or 'context' as their first parameter will
+                receive this context. Tools without such a parameter ignore it.
             
         Returns:
             The result of the tool execution
             
         Raises:
             ValueError: If tool_name is not found or parameters are invalid
+            ToolContextError: If tool expects context but none was provided
         """
         if tool_name not in self.tools:
             raise ValueError(f"Tool '{tool_name}' not found")
@@ -116,16 +132,62 @@ class ToolRunner:
         tool = self.tools[tool_name]
         if 'implementation' not in tool:
             raise ValueError(f"Implementation for tool '{tool_name}' not found")
-            
+        
+        implementation = tool['implementation']
+        
+        # Check if tool expects context injection
+        expects_context = self._tool_expects_context(implementation)
+        
         # Execute the tool
         try:
-            if tool.get('is_async', False):
-                return await tool['implementation'](**parameters)
+            if expects_context:
+                if context is None:
+                    raise ToolContextError(
+                        f"Tool '{tool_name}' requires context (has 'ctx' or 'context' parameter) "
+                        f"but no tool_context was provided to agent.run()"
+                    )
+                # Inject context as first argument
+                if tool.get('is_async', False):
+                    return await implementation(context, **parameters)
+                else:
+                    return await asyncio.to_thread(
+                        lambda: implementation(context, **parameters)
+                    )
             else:
-                # Run sync tools in a thread pool
-                return await asyncio.to_thread(tool['implementation'], **parameters)
+                # Standard execution without context
+                if tool.get('is_async', False):
+                    return await implementation(**parameters)
+                else:
+                    # Run sync tools in a thread pool
+                    return await asyncio.to_thread(implementation, **parameters)
+        except ToolContextError:
+            raise  # Re-raise context errors as-is
         except Exception as e:
             raise ValueError(f"Error executing tool '{tool_name}': {str(e)}")
+    
+    def _tool_expects_context(self, implementation: Callable) -> bool:
+        """Check if a tool implementation expects context injection.
+        
+        A tool expects context if its first parameter is named 'ctx' or 'context'.
+        
+        Args:
+            implementation: The tool function/coroutine
+            
+        Returns:
+            True if the tool expects context, False otherwise
+        """
+        try:
+            sig = inspect.signature(implementation)
+            params = list(sig.parameters.keys())
+            
+            if not params:
+                return False
+            
+            first_param = params[0]
+            return first_param in ('ctx', 'context')
+        except (ValueError, TypeError):
+            # If we can't inspect the signature, assume no context
+            return False
 
     def load_tool_module(self, module_spec: str) -> List[dict]:
         """
@@ -306,8 +368,20 @@ class ToolRunner:
         return tools
 
     @weave.op()
-    async def execute_tool_call(self, tool_call) -> Any:
-        """Execute a tool call and return its raw result."""
+    async def execute_tool_call(
+        self, 
+        tool_call, 
+        context: Optional[ToolContext] = None
+    ) -> Any:
+        """Execute a tool call and return its raw result.
+        
+        Args:
+            tool_call: The tool call object from the LLM response
+            context: Optional context to inject into tools that expect it
+            
+        Returns:
+            The result of the tool execution
+        """
         logger.debug(f"Executing tool call: {tool_call}")
         
         # Get tool name and arguments
@@ -330,16 +404,36 @@ class ToolRunner:
             logger.debug(f"Parsed arguments: {arguments}")
         except json.JSONDecodeError as e:
             raise ValueError(f"Invalid JSON in tool arguments: {e}")
+        
+        implementation = tool['implementation']
+        expects_context = self._tool_expects_context(implementation)
             
         try:
-            if tool['is_async']:
-                result = await tool['implementation'](**arguments)
+            if expects_context:
+                if context is None:
+                    raise ToolContextError(
+                        f"Tool '{tool_name}' requires context (has 'ctx' or 'context' parameter) "
+                        f"but no tool_context was provided to agent.run()"
+                    )
+                # Inject context as first argument
+                if tool['is_async']:
+                    result = await implementation(context, **arguments)
+                else:
+                    result = await asyncio.to_thread(
+                        lambda: implementation(context, **arguments)
+                    )
             else:
-                result = await asyncio.to_thread(tool['implementation'], **arguments)
+                # Standard execution without context
+                if tool['is_async']:
+                    result = await implementation(**arguments)
+                else:
+                    result = await asyncio.to_thread(implementation, **arguments)
                 
             logger.debug(f"Tool execution result: {result}")
             return result
 
+        except ToolContextError:
+            raise  # Re-raise context errors as-is
         except Exception as e:
             logger.error(f"Error executing tool {tool_name}: {e}")
             raise


### PR DESCRIPTION
## Summary

Closes the feature gap with Pydantic AI by adding three opt-in, backward-compatible features:

### 1. Structured Output (`response_type`)
Get validated Pydantic models directly from your agents:
```python
class Invoice(BaseModel):
    vendor: str
    total: float

result = await agent.run(thread, response_type=Invoice)
invoice: Invoice = result.structured_data  # Validated!
```

### 2. Validation Retry (`RetryConfig`)
Automatic retry with error feedback when LLM output doesn't match schema:
```python
agent = Agent(
    retry_config=RetryConfig(max_retries=3, backoff_base_seconds=0.5)
)
```

### 3. Tool Context / Dependency Injection (`tool_context`)
Inject runtime dependencies into tools cleanly:
```python
async def get_orders(ctx: ToolContext, limit: int) -> str:
    db = ctx["db"]
    return await db.query(...)

result = await agent.run(thread, tool_context={"db": database})
```

## Changes

### New Files
- `tyler/models/retry_config.py` - RetryConfig model
- `tests/test_structured_output.py` - 10 tests
- `tests/test_tool_context.py` - 15 tests  
- `examples/600_structured_output.py`
- `examples/601_tool_context.py`
- `directive/specs/structured-output-and-di/` - Spec, Impact, TDR

### Modified Files
- `tyler/models/agent.py` - Added `response_type`, `retry_config`, `tool_context` params
- `tyler/models/execution.py` - Added `structured_data` to AgentResult, new exceptions
- `tyler/utils/tool_runner.py` - Context injection logic
- `tyler/__init__.py` - Export new classes

### Documentation
- New guide: `guides/structured-output.mdx`
- New API refs: `tyler-retryconfig.mdx`, `tyler-structuredoutputerror.mdx`, `tyler-toolcontext.mdx`
- Updated: `tyler-agent.mdx`, `tyler-agentresult.mdx`, `introduction.mdx`

## Testing
- 25 new tests covering all features
- All existing tests pass
- 100% backward compatible

## Breaking Changes
None - all features are opt-in with `None` defaults.