### PR TITLE
feat: add Agent Skills and AGENTS.md support

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,6 +22,7 @@
         "pages": [
           "guides/your-first-agent",
           "guides/adding-tools",
+          "guides/skills",
           "guides/conversation-persistence",
           "guides/streaming-responses",
           "guides/agent-delegation",

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -1,0 +1,264 @@
+---
+title: 'Skills & AGENTS.md'
+description: 'Give your agents reusable instructions — on-demand or always-on'
+---
+
+Slide supports two complementary ways to inject instructions into your agent's system prompt:
+
+- **Skills** — progressively disclosed on-demand via the `activate_skill` tool
+- **AGENTS.md** — eagerly loaded into the system prompt at init time
+
+Both follow open standards: [Agent Skills](https://agentskills.io/specification) and [AGENTS.md](https://agents.md).
+
+**Code Examples**
+
+<CardGroup cols={2}>
+  <Card
+    title="Skills Example"
+    icon="wand-magic-sparkles"
+    href="https://github.com/adamwdraper/slide/blob/main/packages/tyler/examples/108_skills.py"
+  >
+    Progressive skill disclosure in action
+  </Card>
+  <Card
+    title="AGENTS.md Example"
+    icon="file-lines"
+    href="https://github.com/adamwdraper/slide/blob/main/packages/tyler/examples/109_agents_md.py"
+  >
+    Project instructions in action
+  </Card>
+</CardGroup>
+
+## Skills
+
+Skills let you package reusable instructions that agents load only when they need them. Instead of stuffing everything into the system prompt, skills keep the prompt small and focused — the agent sees a short menu of available skills and activates the ones relevant to the current task.
+
+### How skills work
+
+1. You point the agent at one or more skill directories
+2. At init time, only each skill's **name** and **description** appear in the system prompt
+3. When the agent decides it needs a skill, it calls the `activate_skill` tool
+4. The full instructions from `SKILL.md` are returned to the agent as a tool result
+
+### Creating a skill
+
+A skill is a directory containing a `SKILL.md` file. The file has YAML frontmatter (name + description) followed by markdown instructions:
+
+```
+my-project/
+└── skills/
+    ├── code-review/
+    │   └── SKILL.md
+    └── testing/
+        └── SKILL.md
+```
+
+Example `SKILL.md`:
+
+```markdown
+---
+name: code-review
+description: Guidelines for performing thorough code reviews
+---
+# Code Review Skill
+
+## What to look for
+- Correctness: Does the code do what it's supposed to?
+- Readability: Is the code easy to understand?
+- Performance: Are there unnecessary allocations or O(n²) loops?
+- Security: Are inputs validated? Are there injection risks?
+
+## How to format feedback
+- Use inline comments for specific issues
+- Summarize overall impressions at the top
+- Always mention what was done well
+```
+
+#### Frontmatter requirements
+
+| Field | Rules |
+|-------|-------|
+| `name` | Lowercase alphanumeric + hyphens, max 64 chars (e.g. `code-review`) |
+| `description` | Plain text, max 1024 chars |
+
+### Using skills with an agent
+
+```python
+from tyler import Agent
+
+agent = Agent(
+    model_name="gpt-4.1",
+    purpose="A helpful coding assistant",
+    skills=[
+        "./skills/code-review",
+        "./skills/testing",
+    ],
+)
+```
+
+The agent's system prompt will include something like:
+
+```
+# Available Skills
+Use the `activate_skill` tool to load full instructions for any skill.
+
+- **code-review**: Guidelines for performing thorough code reviews
+- **testing**: Guidelines for writing comprehensive tests
+```
+
+When the agent encounters a task that matches a skill, it will call `activate_skill` with the skill name and receive the full instructions.
+
+### Using skills with config files
+
+```yaml
+name: "MyAgent"
+model_name: "gpt-4.1"
+purpose: "A helpful assistant"
+skills:
+  - "./skills/code-review"
+  - "./skills/testing"
+  - "~/shared-skills/documentation"
+```
+
+Relative paths are resolved relative to the config file's directory.
+
+---
+
+## AGENTS.md
+
+AGENTS.md files provide project-level instructions that are eagerly loaded into the agent's system prompt at init time. Unlike skills (which are progressively disclosed), AGENTS.md content is always present — making it ideal for coding standards, API conventions, and other rules that should always apply.
+
+### How it works
+
+1. You point the agent at one or more `AGENTS.md` files (or enable auto-discovery)
+2. At init time, the file contents are loaded and placed in a `<project_instructions>` block in the system prompt
+3. The agent sees these instructions on every interaction
+
+### Creating an AGENTS.md file
+
+Create an `AGENTS.md` file in your project root (or any directory). No special frontmatter or formatting is required — it's just markdown:
+
+```markdown
+# Project Guidelines
+
+## Code Style
+- Use type hints for all function signatures
+- Follow PEP 8 naming conventions
+- Prefer `async`/`await` over threads for I/O-bound operations
+
+## Error Handling
+- Always use specific exception types (never bare `except:`)
+- Include meaningful error messages with context
+- Use `logging` instead of `print` for diagnostics
+
+## API Conventions
+- Use `httpx` for HTTP requests (async-native)
+- Always set timeouts on external calls
+- Return typed dataclasses or Pydantic models, not raw dicts
+```
+
+### Using AGENTS.md with an agent
+
+#### Explicit path
+
+```python
+from tyler import Agent
+
+agent = Agent(
+    model_name="gpt-4.1",
+    purpose="A helpful coding assistant",
+    agents_md="./AGENTS.md",
+)
+```
+
+#### Auto-discovery
+
+Set `agents_md=True` to automatically discover `AGENTS.md` files by walking upward from the current working directory to the filesystem root:
+
+```python
+agent = Agent(
+    model_name="gpt-4.1",
+    purpose="A helpful coding assistant",
+    agents_md=True,
+)
+```
+
+This is useful in monorepos where you might have:
+```
+project-root/AGENTS.md          # Company-wide rules
+project-root/backend/AGENTS.md  # Backend-specific rules
+```
+
+Files are loaded root-first, so the closest file's instructions appear last (taking natural precedence).
+
+#### Multiple files
+
+```python
+agent = Agent(
+    model_name="gpt-4.1",
+    agents_md=["./AGENTS.md", "./docs/coding-standards.md"],
+)
+```
+
+Multiple files are joined with `---` separators.
+
+### Using AGENTS.md with config files
+
+```yaml
+name: "MyAgent"
+model_name: "gpt-4.1"
+purpose: "A helpful assistant"
+
+# Option 1: Auto-discover
+agents_md: true
+
+# Option 2: Explicit path
+# agents_md: "./AGENTS.md"
+
+# Option 3: Multiple files
+# agents_md:
+#   - "./AGENTS.md"
+#   - "./docs/coding-standards.md"
+```
+
+Relative paths are resolved relative to the config file's directory.
+
+### Size limits
+
+AGENTS.md content is guarded against oversized files:
+- Individual files larger than 100,000 characters are skipped with a warning
+- Combined content from multiple files is truncated at 100,000 characters
+
+If your instructions exceed this limit, consider moving task-specific content into skills instead.
+
+---
+
+## When to use which
+
+| | Skills | AGENTS.md |
+|---|---|---|
+| **Loading** | On-demand (progressive disclosure) | Eager (always in prompt) |
+| **Best for** | Task-specific instructions the agent may or may not need | Project-wide rules that always apply |
+| **Prompt impact** | Minimal — only name + description until activated | Full content always present |
+| **Format** | `SKILL.md` with YAML frontmatter | Plain markdown |
+
+Use **AGENTS.md** for short, universal project rules that should always be in context. Use **skills** for detailed, task-specific instructions that only matter sometimes. You can use both together.
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card
+    title="Adding Tools"
+    icon="wrench"
+    href="/guides/adding-tools"
+  >
+    Give your agents more capabilities
+  </Card>
+  <Card
+    title="MCP Integration"
+    icon="plug"
+    href="/guides/mcp-integration"
+  >
+    Connect to external tool servers
+  </Card>
+</CardGroup>

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -57,6 +57,7 @@ Slide gives you everything you need to build, test, and deploy intelligent AI ag
 - **Persistent with conversations**: Equipped with built-in support for threads, messages, and attachments with flexible storage options (in-memory, SQLite, or PostgreSQL)
 - **Type-safe structured outputs**: Get validated Pydantic models from your agents with automatic retry on validation failure—no more manual JSON parsing
 - **Ready-to-use with tools**: Packed with built-in tools for web interaction, file handling, and browser automation—plus dependency injection via `tool_context` for custom tools
+- **Skills and project instructions**: Progressively disclose reusable [Agent Skills](https://agentskills.io/specification) on-demand, and eagerly load project-level guidelines via [AGENTS.md](https://agents.md)
 - **Transparent reasoning**: Access model thinking tokens to see how agents arrive at decisions
 - **Interactive CLI included**: Chat with your agents instantly using the built-in `tyler chat` command, or scaffold new projects with `tyler init`
 - **Evaluation-ready**: Equipped with a framework to test agents safely with mock tools, prebuilt LLM judges, and multi-turn conversation scenarios

--- a/packages/tyler/README.md
+++ b/packages/tyler/README.md
@@ -120,6 +120,56 @@ Integrates with the Model Context Protocol for:
 - Dynamic tool invocation
 - Integration with any MCP-compatible tool ecosystem
 
+### Skills
+
+Progressive skill disclosure following the [Agent Skills](https://agentskills.io/specification) open format:
+- Skills are directories containing a `SKILL.md` file with YAML frontmatter (name, description) and markdown instructions
+- Only skill metadata (name + description) appears in the system prompt — keeping context small
+- Full instructions are loaded on-demand via the `activate_skill` tool when the agent decides it needs them
+- Survives `connect_mcp()` prompt regeneration
+
+```python
+agent = Agent(
+    model_name="gpt-4.1",
+    purpose="A helpful assistant",
+    skills=["./skills/code-review", "./skills/testing"],
+)
+```
+
+Each skill directory contains a `SKILL.md`:
+```markdown
+---
+name: code-review
+description: Guidelines for performing thorough code reviews
+---
+# Code Review Skill
+
+Review code for correctness, readability, and performance...
+```
+
+See `examples/108_skills.py` for a complete example.
+
+### AGENTS.md
+
+Project-level instructions following the [AGENTS.md](https://agents.md) open standard:
+- Eagerly loaded into the system prompt at init time (unlike skills which are progressively disclosed)
+- Auto-discovery walks upward from a base directory, collecting all `AGENTS.md` files (root-first ordering)
+- Supports explicit paths, lists of paths, or boolean auto-discovery
+- Content appears in a `<project_instructions>` block in the system prompt
+
+```python
+# Explicit path
+agent = Agent(model_name="gpt-4.1", agents_md="./AGENTS.md")
+
+# Auto-discover from CWD upward
+agent = Agent(model_name="gpt-4.1", agents_md=True)
+
+# Multiple files
+agent = Agent(model_name="gpt-4.1", agents_md=["./AGENTS.md", "./docs/AGENTS.md"])
+```
+
+See `examples/109_agents_md.py` and `examples/sample-project/AGENTS.md` for a complete example.
+
 ### Storage
 
 Storage is handled by the Narrator package, providing:
@@ -348,6 +398,10 @@ purpose: "A helpful AI assistant"
 tools:
   - "web"
   - "slack"
+skills:
+  - "./skills/code-review"
+  - "./skills/testing"
+agents_md: true  # or "./AGENTS.md" or ["./AGENTS.md", "./docs/AGENTS.md"]
 mcp:
   servers:
     - name: "docs"
@@ -384,6 +438,8 @@ The examples directory includes demonstrations of:
 
 - Basic agent conversations
 - Using built-in and custom tools
+- Agent Skills with progressive disclosure (`108_skills.py`)
+- AGENTS.md project instructions (`109_agents_md.py`)
 - Working with file attachments
 - Image and audio processing
 - Streaming responses

--- a/packages/tyler/examples/108_skills.py
+++ b/packages/tyler/examples/108_skills.py
@@ -1,0 +1,131 @@
+"""Agent Skills example demonstrating progressive skill disclosure.
+
+Skills let you package reusable instructions as SKILL.md files. Only skill
+names and descriptions appear in the system prompt — the full instructions
+are loaded on-demand when the agent calls the activate_skill tool.
+
+This example uses two sample skills included in the ./skills/ directory:
+  - code-review: Review code for bugs and style issues
+  - summarize: Summarize text into concise key points
+
+Run:
+    python 108_skills.py
+"""
+from dotenv import load_dotenv
+load_dotenv()
+
+from tyler.utils.logging import get_logger
+logger = get_logger(__name__)
+
+import os
+import asyncio
+import weave
+import sys
+from pathlib import Path
+from tyler import Agent, Thread, Message
+
+# Initialize weave tracing if WANDB_PROJECT is set
+weave_project = os.getenv("WANDB_PROJECT")
+if weave_project:
+    try:
+        weave.init(weave_project)
+        logger.debug("Weave tracing initialized successfully")
+    except Exception as e:
+        logger.warning(f"Failed to initialize weave tracing: {e}. Continuing without weave.")
+
+# Resolve skill paths relative to this file
+examples_dir = Path(__file__).parent
+skills_dir = examples_dir / "skills"
+
+# Initialize the agent with skills
+agent = Agent(
+    model_name="gpt-4o",
+    purpose="To be a helpful assistant with specialized skills.",
+    skills=[
+        str(skills_dir / "code-review"),
+        str(skills_dir / "summarize"),
+    ]
+)
+
+async def main():
+    print("=" * 60)
+    print("Tyler Skills Example")
+    print("=" * 60)
+    print(f"\nLoaded skills: code-review, summarize")
+    print("The agent will activate skills on-demand as needed.\n")
+
+    # Create a thread
+    thread = Thread()
+
+    # Ask the agent to review some code — this should trigger the
+    # code-review skill activation
+    user_input = (
+        "Please review this Python function:\n\n"
+        "```python\n"
+        "def get_user(id):\n"
+        "    query = f\"SELECT * FROM users WHERE id = {id}\"\n"
+        "    result = db.execute(query)\n"
+        "    return result[0]\n"
+        "```"
+    )
+
+    logger.info("User: %s", user_input)
+
+    message = Message(role="user", content=user_input)
+    thread.add_message(message)
+
+    # Process the thread
+    result = await agent.run(thread)
+
+    logger.info("Assistant: %s", result.content)
+
+    # Show tool usage — should include activate_skill
+    tool_usage = result.thread.get_tool_usage()
+    if tool_usage["total_calls"] > 0:
+        logger.info("Tools used:")
+        for tool_name, count in tool_usage["tools"].items():
+            logger.info("  %s (%d calls)", tool_name, count)
+
+    logger.info("-" * 60)
+
+    # Second turn: ask for a summary — should trigger the summarize skill
+    user_input_2 = (
+        "Now summarize this: Machine learning is a subset of artificial "
+        "intelligence that enables systems to learn from data. It uses "
+        "algorithms to find patterns in large datasets, improving over "
+        "time without explicit programming. Key techniques include "
+        "supervised learning, unsupervised learning, and reinforcement "
+        "learning. Applications range from recommendation engines to "
+        "autonomous vehicles."
+    )
+
+    logger.info("User: %s", user_input_2)
+
+    message_2 = Message(role="user", content=user_input_2)
+    thread.add_message(message_2)
+
+    result_2 = await agent.run(thread)
+
+    logger.info("Assistant: %s", result_2.content)
+
+    tool_usage_2 = result_2.thread.get_tool_usage()
+    if tool_usage_2["total_calls"] > 0:
+        logger.info("Tools used:")
+        for tool_name, count in tool_usage_2["tools"].items():
+            logger.info("  %s (%d calls)", tool_name, count)
+
+    print("\n" + "=" * 60)
+    print("Example complete!")
+    print("\nTo create your own skills:")
+    print("  1. Create a directory (e.g. ./my-skill/)")
+    print("  2. Add a SKILL.md with YAML frontmatter (name, description)")
+    print("  3. Write instructions in the markdown body")
+    print("  4. Pass the path to Agent(skills=[...])")
+    print("=" * 60)
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.warning("Exiting gracefully...")
+        sys.exit(0)

--- a/packages/tyler/examples/109_agents_md.py
+++ b/packages/tyler/examples/109_agents_md.py
@@ -1,0 +1,88 @@
+"""AGENTS.md example demonstrating project-level instructions.
+
+AGENTS.md files provide project-level instructions that are eagerly loaded
+into the agent's system prompt at init time. Unlike skills (progressively
+disclosed on-demand), AGENTS.md content is always present in the prompt.
+
+This example loads a sample AGENTS.md from the ./sample-project/ directory
+and shows how it influences the agent's behavior.
+
+Run:
+    python 109_agents_md.py
+"""
+from dotenv import load_dotenv
+load_dotenv()
+
+from tyler.utils.logging import get_logger
+logger = get_logger(__name__)
+
+import os
+import asyncio
+import weave
+import sys
+from pathlib import Path
+from tyler import Agent, Thread, Message
+
+# Initialize weave tracing if WANDB_PROJECT is set
+weave_project = os.getenv("WANDB_PROJECT")
+if weave_project:
+    try:
+        weave.init(weave_project)
+        logger.debug("Weave tracing initialized successfully")
+    except Exception as e:
+        logger.warning(f"Failed to initialize weave tracing: {e}. Continuing without weave.")
+
+# Resolve the sample AGENTS.md relative to this file
+examples_dir = Path(__file__).parent
+agents_md_path = examples_dir / "sample-project" / "AGENTS.md"
+
+# Initialize the agent with AGENTS.md
+agent = Agent(
+    model_name="gpt-4o",
+    purpose="To be a helpful coding assistant.",
+    agents_md=str(agents_md_path),
+)
+
+async def main():
+    print("=" * 60)
+    print("Tyler AGENTS.md Example")
+    print("=" * 60)
+    print(f"\nLoaded AGENTS.md from: {agents_md_path}")
+    print("The project instructions are now part of the system prompt.\n")
+
+    # Show that the project instructions are in the prompt
+    if "<project_instructions>" in agent._system_prompt:
+        print("Project instructions detected in system prompt.")
+    print()
+
+    # Create a thread
+    thread = Thread()
+
+    # Ask a question that the AGENTS.md instructions should influence
+    user_input = "Write a Python function that fetches user data from an API."
+
+    logger.info("User: %s", user_input)
+
+    message = Message(role="user", content=user_input)
+    thread.add_message(message)
+
+    # Process the thread — the agent should follow AGENTS.md guidelines
+    result = await agent.run(thread)
+
+    logger.info("Assistant: %s", result.content)
+
+    print("\n" + "=" * 60)
+    print("Example complete!")
+    print("\nTo use AGENTS.md in your project:")
+    print("  1. Create an AGENTS.md file in your project root")
+    print("  2. Add coding guidelines, style rules, or project context")
+    print("  3. Pass the path to Agent(agents_md='./AGENTS.md')")
+    print("  4. Or use agents_md=True for auto-discovery")
+    print("=" * 60)
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        logger.warning("Exiting gracefully...")
+        sys.exit(0)

--- a/packages/tyler/examples/README.md
+++ b/packages/tyler/examples/README.md
@@ -68,6 +68,9 @@ Importing and using tool groups.
 ### 108_skills.py
 Agent Skills with progressive disclosure — load reusable SKILL.md instructions on-demand via the `activate_skill` tool.
 
+### 109_agents_md.py
+AGENTS.md project instructions — eagerly load project-level guidelines into the system prompt at init time.
+
 ## Attachment Examples (200-299)
 
 ### 200_attachments.py

--- a/packages/tyler/examples/README.md
+++ b/packages/tyler/examples/README.md
@@ -65,6 +65,9 @@ Weights & Biases integration for experiment tracking.
 ### 107_tools_group_import.py
 Importing and using tool groups.
 
+### 108_skills.py
+Agent Skills with progressive disclosure — load reusable SKILL.md instructions on-demand via the `activate_skill` tool.
+
 ## Attachment Examples (200-299)
 
 ### 200_attachments.py

--- a/packages/tyler/examples/sample-project/AGENTS.md
+++ b/packages/tyler/examples/sample-project/AGENTS.md
@@ -1,0 +1,16 @@
+# Project Guidelines
+
+## Code Style
+- Use type hints for all function signatures
+- Follow PEP 8 naming conventions
+- Prefer `async`/`await` over threads for I/O-bound operations
+
+## Error Handling
+- Always use specific exception types (never bare `except:`)
+- Include meaningful error messages with context
+- Use `logging` instead of `print` for diagnostics
+
+## API Conventions
+- Use `httpx` for HTTP requests (async-native)
+- Always set timeouts on external calls
+- Return typed dataclasses or Pydantic models, not raw dicts

--- a/packages/tyler/examples/skills/code-review/SKILL.md
+++ b/packages/tyler/examples/skills/code-review/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: code-review
+description: Reviews code for bugs, security vulnerabilities, and style issues. Use when the user asks for a code review, wants feedback on a snippet, or mentions reviewing code quality.
+---
+# Code Review Instructions
+
+When reviewing code, follow these steps:
+
+## Step 1: Identify Issues
+Look for:
+- Bugs and logic errors
+- Security vulnerabilities (SQL injection, XSS, etc.)
+- Performance problems (N+1 queries, unnecessary allocations)
+- Missing error handling
+
+## Step 2: Check Style
+Verify:
+- Consistent naming conventions
+- Proper indentation and formatting
+- Clear variable and function names
+- Appropriate use of comments
+
+## Step 3: Suggest Improvements
+For each issue found:
+1. Explain **what** the problem is
+2. Explain **why** it matters
+3. Provide a **concrete fix** with a code snippet
+
+Format your review as a numbered list of findings, ordered by severity (critical first).

--- a/packages/tyler/examples/skills/summarize/SKILL.md
+++ b/packages/tyler/examples/skills/summarize/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: summarize
+description: Summarizes text, articles, or documents into concise key points. Use when the user asks to summarize, condense, or get the gist of content.
+---
+# Summarization Instructions
+
+When summarizing content, follow this structure:
+
+## Format
+- Start with a **one-sentence overview** of the main topic
+- List **3-5 key points** as bullet points
+- End with a **takeaway** or conclusion
+
+## Guidelines
+- Keep the summary under 200 words
+- Use simple, clear language
+- Preserve the original meaning without adding opinions
+- Highlight any numbers, dates, or specific claims

--- a/packages/tyler/tests/models/test_agent_skills.py
+++ b/packages/tyler/tests/models/test_agent_skills.py
@@ -1,0 +1,410 @@
+"""Tests for Agent Skills support.
+
+Tests cover skill loading, validation, activation, system prompt injection,
+config loading, and no-regression scenarios.
+"""
+import pytest
+import yaml
+from pathlib import Path
+from unittest.mock import patch
+
+from tyler import Agent
+from tyler.models.skill import Skill, SkillManager
+from tyler.utils.tool_runner import tool_runner
+from tyler.config import load_config
+
+
+@pytest.fixture(autouse=True)
+def cleanup_activate_skill():
+    """Clean up activate_skill from tool_runner after each test."""
+    yield
+    if "activate_skill" in tool_runner.tools:
+        del tool_runner.tools["activate_skill"]
+    # Also clean up tool attributes if present
+    if "activate_skill" in tool_runner.tool_attributes:
+        del tool_runner.tool_attributes["activate_skill"]
+
+
+def _create_skill_dir(tmp_path, name="test-skill", description="A test skill", body="Do the thing.", extra_frontmatter=None):
+    """Helper to create a skill directory with a SKILL.md file."""
+    skill_dir = tmp_path / name
+    skill_dir.mkdir(exist_ok=True)
+    frontmatter = {"name": name, "description": description}
+    if extra_frontmatter:
+        frontmatter.update(extra_frontmatter)
+    content = f"---\n{yaml.dump(frontmatter)}---\n{body}"
+    (skill_dir / "SKILL.md").write_text(content)
+    return skill_dir
+
+
+class TestSkillLoading:
+    """Test loading skills from directories."""
+
+    def test_skill_loading_from_directory(self, tmp_path):
+        """Valid SKILL.md is parsed correctly."""
+        skill_dir = _create_skill_dir(
+            tmp_path,
+            name="pdf-processing",
+            description="Process PDF files and extract text.",
+            body="# Instructions\nUse pdfplumber to extract text.",
+        )
+
+        manager = SkillManager()
+        skills, tool_defs = manager.load_skills([str(skill_dir)])
+
+        assert len(skills) == 1
+        skill = skills[0]
+        assert skill.name == "pdf-processing"
+        assert skill.description == "Process PDF files and extract text."
+        assert "pdfplumber" in skill.content
+        assert skill.path == skill_dir
+
+    def test_skill_loading_multiple(self, tmp_path):
+        """Multiple skills load correctly."""
+        dir_a = _create_skill_dir(tmp_path, name="skill-a", description="First skill")
+        dir_b = _create_skill_dir(tmp_path, name="skill-b", description="Second skill")
+
+        manager = SkillManager()
+        skills, tool_defs = manager.load_skills([str(dir_a), str(dir_b)])
+
+        assert len(skills) == 2
+        names = {s.name for s in skills}
+        assert names == {"skill-a", "skill-b"}
+
+    def test_skill_missing_skill_md(self, tmp_path):
+        """Directory without SKILL.md is skipped with warning."""
+        empty_dir = tmp_path / "no-skill"
+        empty_dir.mkdir()
+
+        manager = SkillManager()
+        skills, tool_defs = manager.load_skills([str(empty_dir)])
+
+        assert len(skills) == 0
+        assert len(tool_defs) == 0
+
+    def test_skill_extra_metadata(self, tmp_path):
+        """Extra frontmatter fields are captured in metadata."""
+        skill_dir = _create_skill_dir(
+            tmp_path,
+            name="with-meta",
+            description="Has metadata",
+            extra_frontmatter={"version": "1.0", "author": "test"},
+        )
+
+        manager = SkillManager()
+        skills, _ = manager.load_skills([str(skill_dir)])
+
+        assert skills[0].metadata == {"version": "1.0", "author": "test"}
+
+
+class TestSkillValidation:
+    """Test frontmatter validation per the Agent Skills spec."""
+
+    def test_invalid_name_uppercase(self, tmp_path):
+        """Name with uppercase letters is rejected."""
+        skill_dir = _create_skill_dir(tmp_path, name="BadName", description="test")
+
+        manager = SkillManager()
+        with pytest.raises(ValueError, match="invalid"):
+            manager.load_skills([str(skill_dir)])
+
+    def test_invalid_name_spaces(self, tmp_path):
+        """Name with spaces is rejected."""
+        skill_dir = _create_skill_dir(tmp_path, name="bad name", description="test")
+
+        manager = SkillManager()
+        with pytest.raises(ValueError, match="invalid"):
+            manager.load_skills([str(skill_dir)])
+
+    def test_invalid_name_too_long(self, tmp_path):
+        """Name exceeding 64 chars is rejected."""
+        long_name = "a" * 65
+        skill_dir = _create_skill_dir(tmp_path, name=long_name, description="test")
+
+        manager = SkillManager()
+        with pytest.raises(ValueError, match="exceeds"):
+            manager.load_skills([str(skill_dir)])
+
+    def test_invalid_description_too_long(self, tmp_path):
+        """Description exceeding 1024 chars is rejected."""
+        long_desc = "x" * 1025
+        skill_dir = _create_skill_dir(tmp_path, name="valid-name", description=long_desc)
+
+        manager = SkillManager()
+        with pytest.raises(ValueError, match="exceeds"):
+            manager.load_skills([str(skill_dir)])
+
+    def test_missing_frontmatter_delimiters(self, tmp_path):
+        """SKILL.md without --- delimiters raises error."""
+        skill_dir = tmp_path / "bad-format"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text("No frontmatter here, just text.")
+
+        manager = SkillManager()
+        with pytest.raises(ValueError, match="frontmatter"):
+            manager.load_skills([str(skill_dir)])
+
+    def test_missing_name_in_frontmatter(self, tmp_path):
+        """SKILL.md without name in frontmatter raises error."""
+        skill_dir = tmp_path / "no-name"
+        skill_dir.mkdir()
+        content = "---\ndescription: Has description but no name\n---\nBody text"
+        (skill_dir / "SKILL.md").write_text(content)
+
+        manager = SkillManager()
+        with pytest.raises(ValueError, match="missing 'name'"):
+            manager.load_skills([str(skill_dir)])
+
+    def test_missing_description_in_frontmatter(self, tmp_path):
+        """SKILL.md without description in frontmatter raises error."""
+        skill_dir = tmp_path / "no-desc"
+        skill_dir.mkdir()
+        content = "---\nname: no-desc\n---\nBody text"
+        (skill_dir / "SKILL.md").write_text(content)
+
+        manager = SkillManager()
+        with pytest.raises(ValueError, match="missing 'description'"):
+            manager.load_skills([str(skill_dir)])
+
+    def test_valid_name_with_hyphens_and_numbers(self, tmp_path):
+        """Name with hyphens and numbers is valid."""
+        skill_dir = _create_skill_dir(tmp_path, name="my-skill-v2", description="Valid skill")
+
+        manager = SkillManager()
+        skills, _ = manager.load_skills([str(skill_dir)])
+        assert skills[0].name == "my-skill-v2"
+
+
+class TestActivateSkill:
+    """Test the activate_skill tool implementation."""
+
+    @pytest.mark.asyncio
+    async def test_activate_skill_returns_content(self, tmp_path):
+        """activate_skill tool returns the full SKILL.md body."""
+        body = "# Step 1\nDo this.\n\n# Step 2\nDo that."
+        skill_dir = _create_skill_dir(
+            tmp_path, name="my-skill", description="A skill", body=body
+        )
+
+        manager = SkillManager()
+        skills, tool_defs = manager.load_skills([str(skill_dir)])
+
+        # Execute via tool_runner
+        result = await tool_runner.run_tool_async("activate_skill", {"name": "my-skill"})
+        assert result == body
+
+    @pytest.mark.asyncio
+    async def test_activate_skill_unknown_name(self, tmp_path):
+        """activate_skill with unknown name returns helpful error."""
+        skill_dir = _create_skill_dir(tmp_path, name="known-skill", description="Known")
+
+        manager = SkillManager()
+        manager.load_skills([str(skill_dir)])
+
+        result = await tool_runner.run_tool_async("activate_skill", {"name": "unknown"})
+        assert "Unknown skill" in result
+        assert "known-skill" in result
+
+    def test_activate_skill_tool_registered(self, tmp_path):
+        """activate_skill is registered in the global tool_runner."""
+        skill_dir = _create_skill_dir(tmp_path, name="reg-test", description="Test")
+
+        manager = SkillManager()
+        manager.load_skills([str(skill_dir)])
+
+        assert "activate_skill" in tool_runner.tools
+
+    def test_activate_skill_tool_attributes(self, tmp_path):
+        """activate_skill has source='skills' attribute."""
+        skill_dir = _create_skill_dir(tmp_path, name="attr-test", description="Test")
+
+        manager = SkillManager()
+        manager.load_skills([str(skill_dir)])
+
+        attrs = tool_runner.get_tool_attributes("activate_skill")
+        assert attrs == {"source": "skills"}
+
+    def test_activate_skill_tool_definition(self, tmp_path):
+        """activate_skill tool definition has correct shape."""
+        skill_dir = _create_skill_dir(tmp_path, name="def-test", description="Test")
+
+        manager = SkillManager()
+        _, tool_defs = manager.load_skills([str(skill_dir)])
+
+        assert len(tool_defs) == 1
+        tool_def = tool_defs[0]
+        assert tool_def["type"] == "function"
+        assert tool_def["function"]["name"] == "activate_skill"
+        assert "name" in tool_def["function"]["parameters"]["properties"]
+
+
+class TestSkillsInSystemPrompt:
+    """Test that skills metadata appears in the system prompt."""
+
+    def test_skills_in_system_prompt(self, tmp_path):
+        """System prompt includes available_skills block when skills configured."""
+        skill_dir = _create_skill_dir(
+            tmp_path,
+            name="code-review",
+            description="Review code for quality and bugs.",
+        )
+
+        agent = Agent(
+            model_name="gpt-4.1",
+            purpose="test",
+            skills=[str(skill_dir)],
+        )
+
+        assert "<available_skills>" in agent._system_prompt
+        assert "code-review" in agent._system_prompt
+        assert "Review code for quality and bugs." in agent._system_prompt
+        assert "activate_skill" in agent._system_prompt
+
+    def test_multiple_skills_in_prompt(self, tmp_path):
+        """Multiple skills listed in system prompt."""
+        dir_a = _create_skill_dir(tmp_path, name="skill-a", description="First")
+        dir_b = _create_skill_dir(tmp_path, name="skill-b", description="Second")
+
+        agent = Agent(
+            model_name="gpt-4.1",
+            purpose="test",
+            skills=[str(dir_a), str(dir_b)],
+        )
+
+        assert "skill-a" in agent._system_prompt
+        assert "skill-b" in agent._system_prompt
+
+
+class TestAgentWithNoSkills:
+    """Test that agents without skills work normally (no regression)."""
+
+    def test_agent_with_no_skills(self):
+        """Agent with skills=[] has no skills in prompt."""
+        agent = Agent(model_name="gpt-4.1", purpose="test")
+
+        assert "<available_skills>" not in agent._system_prompt
+        assert "activate_skill" not in agent._system_prompt
+
+    def test_agent_with_empty_skills_list(self):
+        """Explicitly passing skills=[] causes no issues."""
+        agent = Agent(model_name="gpt-4.1", purpose="test", skills=[])
+
+        assert len(agent._processed_tools) == 0
+        assert "<available_skills>" not in agent._system_prompt
+
+    def test_agent_with_tools_and_no_skills(self):
+        """Tools work normally without skills."""
+        agent = Agent(model_name="gpt-4.1", purpose="test", tools=["web"])
+
+        assert len(agent._processed_tools) > 0
+        assert "<available_skills>" not in agent._system_prompt
+
+    def test_agent_with_tools_and_skills(self, tmp_path):
+        """Tools and skills coexist."""
+        skill_dir = _create_skill_dir(
+            tmp_path, name="my-skill", description="A skill"
+        )
+
+        agent = Agent(
+            model_name="gpt-4.1",
+            purpose="test",
+            tools=["web"],
+            skills=[str(skill_dir)],
+        )
+
+        tool_names = {t["function"]["name"] for t in agent._processed_tools}
+        assert "activate_skill" in tool_names
+        # Web tools should also be present
+        assert any(n.startswith("web-") for n in tool_names)
+        assert "<available_skills>" in agent._system_prompt
+
+
+class TestSkillsYamlConfig:
+    """Test skills configuration via YAML config files."""
+
+    def test_skills_in_config(self, tmp_path):
+        """Skills paths are processed from YAML config."""
+        # Create a skill directory
+        skill_dir = _create_skill_dir(tmp_path, name="config-skill", description="From config")
+
+        config_file = tmp_path / "config.yaml"
+        config_data = {
+            "name": "Agent",
+            "skills": [str(skill_dir)],
+        }
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        assert "skills" in result
+        assert len(result["skills"]) == 1
+        assert result["skills"][0] == str(skill_dir)
+
+    def test_skills_relative_path_in_config(self, tmp_path):
+        """Relative skill paths are resolved relative to config directory."""
+        skill_dir = _create_skill_dir(tmp_path, name="rel-skill", description="Relative")
+
+        config_file = tmp_path / "config.yaml"
+        config_data = {"skills": ["./rel-skill"]}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        # Should be resolved to an absolute path
+        resolved = Path(result["skills"][0])
+        assert resolved.is_absolute()
+        assert resolved.name == "rel-skill"
+
+    def test_skills_home_path_in_config(self, tmp_path):
+        """Home (~) skill paths are expanded."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {"skills": ["~/my-skills/code-review"]}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        # Should be expanded (no ~ remaining)
+        assert "~" not in result["skills"][0]
+
+    def test_skills_absolute_path_in_config(self, tmp_path):
+        """Absolute skill paths are passed through."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {"skills": ["/opt/skills/code-review"]}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        assert result["skills"][0] == "/opt/skills/code-review"
+
+    def test_config_without_skills(self, tmp_path):
+        """Config without skills key works fine."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {"name": "Agent"}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        assert "skills" not in result
+
+
+class TestToolNameCollision:
+    """Test activate_skill tool name collision detection."""
+
+    def test_collision_with_existing_tool(self, tmp_path):
+        """Raises ValueError if activate_skill is already registered."""
+        skill_dir = _create_skill_dir(tmp_path, name="collision-test", description="Test")
+
+        # Pre-register a tool named activate_skill
+        tool_runner.register_tool(
+            name="activate_skill",
+            implementation=lambda: "existing",
+        )
+
+        try:
+            manager = SkillManager()
+            with pytest.raises(ValueError, match="already registered"):
+                manager.load_skills([str(skill_dir)])
+        finally:
+            # Clean up the pre-registered tool
+            if "activate_skill" in tool_runner.tools:
+                del tool_runner.tools["activate_skill"]

--- a/packages/tyler/tests/models/test_agents_md.py
+++ b/packages/tyler/tests/models/test_agents_md.py
@@ -134,13 +134,26 @@ class TestLoading:
 
         assert result == ""
 
-    def test_load_truncation(self, tmp_path):
-        """Content exceeding MAX_AGENTS_MD_SIZE is truncated."""
+    def test_load_oversized_file_skipped(self, tmp_path):
+        """Single file exceeding MAX_AGENTS_MD_SIZE is skipped."""
         big_content = "x" * (MAX_AGENTS_MD_SIZE + 1000)
         agents_file = tmp_path / "AGENTS.md"
         agents_file.write_text(big_content)
 
         result = load_agents_md(str(agents_file))
+
+        assert result == ""
+
+    def test_load_combined_truncation(self, tmp_path):
+        """Combined content from multiple files is truncated at the limit."""
+        # Two files that individually fit but together exceed the limit
+        half = MAX_AGENTS_MD_SIZE // 2 + 100
+        file_a = tmp_path / "A.md"
+        file_b = tmp_path / "B.md"
+        file_a.write_text("a" * half)
+        file_b.write_text("b" * half)
+
+        result = load_agents_md([str(file_a), str(file_b)])
 
         assert len(result) <= MAX_AGENTS_MD_SIZE
 

--- a/packages/tyler/tests/models/test_agents_md.py
+++ b/packages/tyler/tests/models/test_agents_md.py
@@ -24,6 +24,12 @@ def cleanup_activate_skill():
         del tool_runner.tool_attributes["activate_skill"]
 
 
+def _within(paths, root):
+    """Filter discovered paths to only those within root (for test isolation)."""
+    root = root.resolve()
+    return [p for p in paths if root in p.parents or p.parent == root]
+
+
 class TestDiscovery:
     """Test hierarchical AGENTS.md discovery."""
 
@@ -35,7 +41,7 @@ class TestDiscovery:
         sub.mkdir()
         (sub / "AGENTS.md").write_text("Sub instructions")
 
-        found = discover_agents_md(sub)
+        found = _within(discover_agents_md(sub), tmp_path)
 
         assert len(found) == 2
         # Root-first ordering
@@ -48,17 +54,17 @@ class TestDiscovery:
         sub = tmp_path / "sub"
         sub.mkdir()
 
-        found = discover_agents_md(sub)
+        found = _within(discover_agents_md(sub), tmp_path)
 
         assert len(found) == 1
         assert found[0] == (tmp_path / "AGENTS.md").resolve()
 
     def test_discover_none_found(self, tmp_path):
-        """Returns empty list when no AGENTS.md found anywhere."""
+        """Returns empty list when no AGENTS.md found in tmp_path tree."""
         sub = tmp_path / "sub"
         sub.mkdir()
 
-        found = discover_agents_md(sub)
+        found = _within(discover_agents_md(sub), tmp_path)
 
         assert found == []
 
@@ -73,7 +79,7 @@ class TestDiscovery:
         b.mkdir()
         (b / "AGENTS.md").write_text("3")
 
-        found = discover_agents_md(b)
+        found = _within(discover_agents_md(b), tmp_path)
 
         assert len(found) == 3
         assert found[0] == (tmp_path / "AGENTS.md").resolve()

--- a/packages/tyler/tests/models/test_agents_md.py
+++ b/packages/tyler/tests/models/test_agents_md.py
@@ -1,0 +1,386 @@
+"""Tests for AGENTS.md support.
+
+Tests cover discovery, loading, system prompt injection, MCP survival,
+YAML config processing, and no-regression scenarios.
+"""
+import pytest
+import yaml
+from pathlib import Path
+from unittest.mock import patch
+
+from tyler import Agent
+from tyler.models.agents_md import discover_agents_md, load_agents_md, MAX_AGENTS_MD_SIZE
+from tyler.config import load_config
+from tyler.utils.tool_runner import tool_runner
+
+
+@pytest.fixture(autouse=True)
+def cleanup_activate_skill():
+    """Clean up activate_skill from tool_runner after each test."""
+    yield
+    if "activate_skill" in tool_runner.tools:
+        del tool_runner.tools["activate_skill"]
+    if "activate_skill" in tool_runner.tool_attributes:
+        del tool_runner.tool_attributes["activate_skill"]
+
+
+class TestDiscovery:
+    """Test hierarchical AGENTS.md discovery."""
+
+    def test_discover_from_nested_dir(self, tmp_path):
+        """Discovers AGENTS.md files walking upward from a nested directory."""
+        # Create hierarchy: root/AGENTS.md, root/sub/AGENTS.md
+        (tmp_path / "AGENTS.md").write_text("Root instructions")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+        (sub / "AGENTS.md").write_text("Sub instructions")
+
+        found = discover_agents_md(sub)
+
+        assert len(found) == 2
+        # Root-first ordering
+        assert found[0] == (tmp_path / "AGENTS.md").resolve()
+        assert found[1] == (sub / "AGENTS.md").resolve()
+
+    def test_discover_root_only(self, tmp_path):
+        """Finds AGENTS.md only at root level."""
+        (tmp_path / "AGENTS.md").write_text("Root only")
+        sub = tmp_path / "sub"
+        sub.mkdir()
+
+        found = discover_agents_md(sub)
+
+        assert len(found) == 1
+        assert found[0] == (tmp_path / "AGENTS.md").resolve()
+
+    def test_discover_none_found(self, tmp_path):
+        """Returns empty list when no AGENTS.md found anywhere."""
+        sub = tmp_path / "sub"
+        sub.mkdir()
+
+        found = discover_agents_md(sub)
+
+        assert found == []
+
+    def test_discover_ordering_root_first(self, tmp_path):
+        """Result ordering is root-first, closest-last."""
+        # root/AGENTS.md, root/a/AGENTS.md, root/a/b/AGENTS.md
+        (tmp_path / "AGENTS.md").write_text("1")
+        a = tmp_path / "a"
+        a.mkdir()
+        (a / "AGENTS.md").write_text("2")
+        b = a / "b"
+        b.mkdir()
+        (b / "AGENTS.md").write_text("3")
+
+        found = discover_agents_md(b)
+
+        assert len(found) == 3
+        assert found[0] == (tmp_path / "AGENTS.md").resolve()
+        assert found[1] == (a / "AGENTS.md").resolve()
+        assert found[2] == (b / "AGENTS.md").resolve()
+
+
+class TestLoading:
+    """Test load_agents_md with various config variants."""
+
+    def test_load_none_returns_empty(self):
+        """agents_md=None returns empty string."""
+        assert load_agents_md(None) == ""
+
+    def test_load_false_returns_empty(self):
+        """agents_md=False returns empty string."""
+        assert load_agents_md(False) == ""
+
+    def test_load_true_auto_discovers(self, tmp_path):
+        """agents_md=True triggers auto-discovery from base_dir."""
+        (tmp_path / "AGENTS.md").write_text("Auto-discovered content")
+
+        result = load_agents_md(True, base_dir=tmp_path)
+
+        assert "Auto-discovered content" in result
+
+    def test_load_explicit_path(self, tmp_path):
+        """agents_md=str loads a single file."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Explicit file content")
+
+        result = load_agents_md(str(agents_file))
+
+        assert result == "Explicit file content"
+
+    def test_load_multiple_paths(self, tmp_path):
+        """agents_md=List[str] loads multiple files, joined with separator."""
+        file_a = tmp_path / "A.md"
+        file_b = tmp_path / "B.md"
+        file_a.write_text("File A")
+        file_b.write_text("File B")
+
+        result = load_agents_md([str(file_a), str(file_b)])
+
+        assert "File A" in result
+        assert "File B" in result
+        assert "\n\n---\n\n" in result
+
+    def test_load_missing_file_skipped(self, tmp_path):
+        """Missing file is skipped with warning, not an error."""
+        result = load_agents_md(str(tmp_path / "nonexistent.md"))
+
+        assert result == ""
+
+    def test_load_truncation(self, tmp_path):
+        """Content exceeding MAX_AGENTS_MD_SIZE is truncated."""
+        big_content = "x" * (MAX_AGENTS_MD_SIZE + 1000)
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text(big_content)
+
+        result = load_agents_md(str(agents_file))
+
+        assert len(result) <= MAX_AGENTS_MD_SIZE
+
+    def test_load_true_no_files_found(self, tmp_path):
+        """agents_md=True with no files returns empty string."""
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        result = load_agents_md(True, base_dir=empty_dir)
+
+        assert result == ""
+
+
+class TestSystemPromptInjection:
+    """Test that AGENTS.md content appears in the system prompt."""
+
+    def test_agents_md_in_system_prompt(self, tmp_path):
+        """System prompt includes <project_instructions> block."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("# Project Rules\nAlways use type hints.")
+
+        agent = Agent(
+            model_name="gpt-4.1",
+            purpose="test",
+            agents_md=str(agents_file),
+        )
+
+        assert "<project_instructions>" in agent._system_prompt
+        assert "Always use type hints." in agent._system_prompt
+        assert "</project_instructions>" in agent._system_prompt
+
+    def test_no_agents_md_no_block(self):
+        """Agent with agents_md=None has no <project_instructions> block."""
+        agent = Agent(model_name="gpt-4.1", purpose="test")
+
+        assert "<project_instructions>" not in agent._system_prompt
+
+    def test_agents_md_coexists_with_skills(self, tmp_path):
+        """AGENTS.md and skills both appear in system prompt."""
+        # Create AGENTS.md
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Project instructions here.")
+
+        # Create a skill
+        skill_dir = tmp_path / "my-skill"
+        skill_dir.mkdir()
+        frontmatter = {"name": "my-skill", "description": "A test skill"}
+        (skill_dir / "SKILL.md").write_text(
+            f"---\n{yaml.dump(frontmatter)}---\nSkill body."
+        )
+
+        agent = Agent(
+            model_name="gpt-4.1",
+            purpose="test",
+            agents_md=str(agents_file),
+            skills=[str(skill_dir)],
+        )
+
+        assert "<project_instructions>" in agent._system_prompt
+        assert "Project instructions here." in agent._system_prompt
+        assert "<available_skills>" in agent._system_prompt
+        assert "my-skill" in agent._system_prompt
+
+    def test_project_instructions_before_skills(self, tmp_path):
+        """<project_instructions> appears before <available_skills> in prompt."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Project instructions")
+
+        skill_dir = tmp_path / "test-skill"
+        skill_dir.mkdir()
+        frontmatter = {"name": "test-skill", "description": "Test"}
+        (skill_dir / "SKILL.md").write_text(
+            f"---\n{yaml.dump(frontmatter)}---\nBody."
+        )
+
+        agent = Agent(
+            model_name="gpt-4.1",
+            purpose="test",
+            agents_md=str(agents_file),
+            skills=[str(skill_dir)],
+        )
+
+        pi_pos = agent._system_prompt.index("<project_instructions>")
+        as_pos = agent._system_prompt.index("<available_skills>")
+        assert pi_pos < as_pos
+
+
+class TestSurvivesConnectMcp:
+    """Test that AGENTS.md content survives connect_mcp() prompt regeneration."""
+
+    @pytest.mark.asyncio
+    async def test_connect_mcp_preserves_agents_md(self, tmp_path):
+        """AGENTS.md content survives connect_mcp() prompt regeneration."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Must survive MCP reconnect.")
+
+        agent = Agent(
+            model_name="gpt-4.1",
+            purpose="test",
+            agents_md=str(agents_file),
+            mcp={"servers": [{"name": "test", "transport": "stdio", "command": "echo"}]},
+        )
+
+        # Before connect_mcp
+        assert "<project_instructions>" in agent._system_prompt
+        assert "Must survive MCP reconnect." in agent._system_prompt
+
+        # Mock MCP connection
+        mcp_tool_def = {
+            "definition": {
+                "type": "function",
+                "function": {
+                    "name": "mcp_fake_tool",
+                    "description": "A fake MCP tool",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            "implementation": lambda: "ok",
+        }
+        with patch(
+            "tyler.mcp.config_loader._load_mcp_config",
+            return_value=([mcp_tool_def], lambda: None),
+        ), patch(
+            "tyler.mcp.config_loader._validate_mcp_config",
+        ):
+            await agent.connect_mcp()
+
+        # After connect_mcp: AGENTS.md STILL present
+        assert "<project_instructions>" in agent._system_prompt
+        assert "Must survive MCP reconnect." in agent._system_prompt
+
+
+class TestYamlConfig:
+    """Test agents_md configuration via YAML config files."""
+
+    def test_agents_md_path_in_config(self, tmp_path):
+        """Explicit agents_md path is resolved from config."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Config content")
+
+        config_file = tmp_path / "config.yaml"
+        config_data = {"name": "Agent", "agents_md": str(agents_file)}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        assert "agents_md" in result
+        assert result["agents_md"] == str(agents_file)
+
+    def test_agents_md_relative_path_in_config(self, tmp_path):
+        """Relative agents_md path resolved relative to config directory."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Relative content")
+
+        config_file = tmp_path / "config.yaml"
+        config_data = {"agents_md": "./AGENTS.md"}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        resolved = Path(result["agents_md"])
+        assert resolved.is_absolute()
+        assert resolved.name == "AGENTS.md"
+
+    def test_agents_md_list_in_config(self, tmp_path):
+        """List of agents_md paths are all resolved."""
+        file_a = tmp_path / "A.md"
+        file_b = tmp_path / "B.md"
+        file_a.write_text("A")
+        file_b.write_text("B")
+
+        config_file = tmp_path / "config.yaml"
+        config_data = {"agents_md": ["./A.md", "./B.md"]}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        assert isinstance(result["agents_md"], list)
+        assert len(result["agents_md"]) == 2
+        assert all(Path(p).is_absolute() for p in result["agents_md"])
+
+    def test_agents_md_bool_in_config(self, tmp_path):
+        """Boolean agents_md passes through unchanged."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {"agents_md": True}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        assert result["agents_md"] is True
+
+    def test_agents_md_disabled_in_config(self, tmp_path):
+        """agents_md=false in config passes through as False."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {"agents_md": False}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        assert result["agents_md"] is False
+
+    def test_config_without_agents_md(self, tmp_path):
+        """Config without agents_md key works fine."""
+        config_file = tmp_path / "config.yaml"
+        config_data = {"name": "Agent"}
+        config_file.write_text(yaml.dump(config_data))
+
+        result = load_config(str(config_file))
+
+        assert "agents_md" not in result
+
+
+class TestNoRegression:
+    """Test that agents without agents_md work normally."""
+
+    def test_agent_default_no_project_instructions(self):
+        """Default agent has no <project_instructions> block."""
+        agent = Agent(model_name="gpt-4.1", purpose="test")
+
+        assert "<project_instructions>" not in agent._system_prompt
+
+    def test_agent_with_agents_md_none(self):
+        """Explicitly passing agents_md=None has no effect."""
+        agent = Agent(model_name="gpt-4.1", purpose="test", agents_md=None)
+
+        assert "<project_instructions>" not in agent._system_prompt
+
+    def test_agent_with_agents_md_false(self):
+        """Explicitly passing agents_md=False has no effect."""
+        agent = Agent(model_name="gpt-4.1", purpose="test", agents_md=False)
+
+        assert "<project_instructions>" not in agent._system_prompt
+
+    def test_agent_with_tools_and_agents_md(self, tmp_path):
+        """Tools work normally alongside agents_md."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Project rules.")
+
+        agent = Agent(
+            model_name="gpt-4.1",
+            purpose="test",
+            tools=["web"],
+            agents_md=str(agents_file),
+        )
+
+        tool_names = {t["function"]["name"] for t in agent._processed_tools}
+        assert any(n.startswith("web-") for n in tool_names)
+        assert "<project_instructions>" in agent._system_prompt
+        assert "Project rules." in agent._system_prompt

--- a/packages/tyler/tyler/config.py
+++ b/packages/tyler/tyler/config.py
@@ -159,6 +159,10 @@ def load_config(config_path: Optional[str] = None) -> Dict[str, Any]:
     if 'skills' in config and isinstance(config['skills'], list):
         config['skills'] = _process_skills_list(config['skills'], resolved_path.parent)
 
+    # Process agents_md paths (resolve relative paths against config dir)
+    if 'agents_md' in config:
+        config['agents_md'] = _process_agents_md(config['agents_md'], resolved_path.parent)
+
     return config
 
 
@@ -404,4 +408,56 @@ def _process_skills_list(skills: List[str], config_dir: Path) -> List[str]:
         resolved.append(str(path))
 
     return resolved
+
+
+def _resolve_agents_md_path(path_str: str, config_dir: Path) -> str:
+    """Resolve an agents_md path relative to config directory.
+
+    Args:
+        path_str: Path string (may be relative, absolute, or use ~)
+        config_dir: Directory containing config file (for relative paths)
+
+    Returns:
+        Resolved absolute path string
+    """
+    path = Path(path_str)
+    if path_str.startswith('~'):
+        path = path.expanduser()
+    elif not path.is_absolute():
+        path = (config_dir / path_str).resolve()
+    return str(path)
+
+
+def _process_agents_md(agents_md: Any, config_dir: Path) -> Any:
+    """Process agents_md config value: resolve paths relative to config directory.
+
+    Handles all config variants:
+    - bool (True/False): pass through unchanged
+    - str: resolve as a path
+    - list of str: resolve each as a path
+    - None or other: pass through unchanged
+
+    Args:
+        agents_md: agents_md value from config
+        config_dir: Directory containing config file (for relative paths)
+
+    Returns:
+        Processed agents_md value with paths resolved
+    """
+    if isinstance(agents_md, bool) or agents_md is None:
+        return agents_md
+
+    if isinstance(agents_md, str):
+        return _resolve_agents_md_path(agents_md, config_dir)
+
+    if isinstance(agents_md, list):
+        resolved = []
+        for item in agents_md:
+            if isinstance(item, str):
+                resolved.append(_resolve_agents_md_path(item, config_dir))
+            else:
+                logger.warning(f"Skipping non-string agents_md path: {item}")
+        return resolved
+
+    return agents_md
 

--- a/packages/tyler/tyler/models/agents_md.py
+++ b/packages/tyler/tyler/models/agents_md.py
@@ -96,6 +96,13 @@ def load_agents_md(
             continue
 
         try:
+            file_size = resolved.stat().st_size
+            if file_size > MAX_AGENTS_MD_SIZE:
+                logger.warning(
+                    f"AGENTS.md file {resolved} is {file_size} bytes, "
+                    f"exceeds {MAX_AGENTS_MD_SIZE} limit, skipping"
+                )
+                continue
             text = resolved.read_text(encoding="utf-8")
         except Exception as e:
             logger.warning(f"Failed to read {resolved}: {e}, skipping")

--- a/packages/tyler/tyler/models/agents_md.py
+++ b/packages/tyler/tyler/models/agents_md.py
@@ -88,7 +88,6 @@ def load_agents_md(
         return ""
 
     contents: List[str] = []
-    total_size = 0
 
     for path in paths:
         resolved = path.expanduser().resolve()
@@ -102,17 +101,12 @@ def load_agents_md(
             logger.warning(f"Failed to read {resolved}: {e}, skipping")
             continue
 
-        total_size += len(text)
-        if total_size > MAX_AGENTS_MD_SIZE:
-            logger.warning(
-                f"AGENTS.md content exceeds {MAX_AGENTS_MD_SIZE} chars, truncating"
-            )
-            # Truncate this file's contribution to stay within limit
-            allowed = MAX_AGENTS_MD_SIZE - (total_size - len(text))
-            if allowed > 0:
-                contents.append(text[:allowed])
-            break
-
         contents.append(text)
 
-    return "\n\n---\n\n".join(contents)
+    result = "\n\n---\n\n".join(contents)
+    if len(result) > MAX_AGENTS_MD_SIZE:
+        logger.warning(
+            f"AGENTS.md content exceeds {MAX_AGENTS_MD_SIZE} chars, truncating"
+        )
+        result = result[:MAX_AGENTS_MD_SIZE]
+    return result

--- a/packages/tyler/tyler/models/agents_md.py
+++ b/packages/tyler/tyler/models/agents_md.py
@@ -1,0 +1,118 @@
+"""AGENTS.md loader for project-level agent instructions.
+
+Implements the AGENTS.md open standard — project-level instruction files
+that are auto-loaded into the agent's system prompt at init time.
+Unlike skills (progressively disclosed), AGENTS.md content is eagerly loaded.
+
+See: https://agents.md
+"""
+import logging
+from pathlib import Path
+from typing import List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+# Guard against huge files
+MAX_AGENTS_MD_SIZE = 100_000
+
+
+def discover_agents_md(start_dir: Union[str, Path]) -> List[Path]:
+    """Walk from start_dir upward, collecting all AGENTS.md files.
+
+    Returns paths ordered root-first, closest-last so that the closest
+    file's instructions naturally take precedence (appended last).
+
+    Args:
+        start_dir: Directory to start searching from.
+
+    Returns:
+        List of Path objects to AGENTS.md files, root-first ordering.
+    """
+    start = Path(start_dir).resolve()
+    found: List[Path] = []
+
+    current = start
+    while True:
+        candidate = current / "AGENTS.md"
+        if candidate.is_file():
+            found.append(candidate)
+        parent = current.parent
+        if parent == current:
+            # Reached filesystem root
+            break
+        current = parent
+
+    # found is closest-first; reverse to root-first
+    found.reverse()
+    return found
+
+
+def load_agents_md(
+    agents_md: Optional[Union[bool, str, List[str]]] = None,
+    base_dir: Optional[Union[str, Path]] = None,
+) -> str:
+    """Load AGENTS.md content based on the configuration value.
+
+    Args:
+        agents_md: Configuration value controlling AGENTS.md loading:
+            - None (default): no auto-discovery, return ""
+            - True: auto-discover from base_dir (or CWD) upward
+            - False: explicitly disabled, return ""
+            - str: explicit path to one file
+            - List[str]: multiple explicit paths
+        base_dir: Base directory for auto-discovery (used when agents_md=True).
+                  Defaults to CWD if not provided.
+
+    Returns:
+        Combined content string from all loaded AGENTS.md files,
+        joined with "\\n\\n---\\n\\n". Empty string if nothing loaded.
+    """
+    if agents_md is None or agents_md is False:
+        return ""
+
+    paths: List[Path] = []
+
+    if agents_md is True:
+        dir_to_search = Path(base_dir) if base_dir else Path.cwd()
+        paths = discover_agents_md(dir_to_search)
+    elif isinstance(agents_md, str):
+        paths = [Path(agents_md)]
+    elif isinstance(agents_md, list):
+        paths = [Path(p) for p in agents_md]
+    else:
+        logger.warning(f"Unexpected agents_md type: {type(agents_md)}, ignoring")
+        return ""
+
+    if not paths:
+        logger.debug("No AGENTS.md files found")
+        return ""
+
+    contents: List[str] = []
+    total_size = 0
+
+    for path in paths:
+        resolved = path.expanduser().resolve()
+        if not resolved.is_file():
+            logger.warning(f"AGENTS.md not found: {resolved}, skipping")
+            continue
+
+        try:
+            text = resolved.read_text(encoding="utf-8")
+        except Exception as e:
+            logger.warning(f"Failed to read {resolved}: {e}, skipping")
+            continue
+
+        total_size += len(text)
+        if total_size > MAX_AGENTS_MD_SIZE:
+            logger.warning(
+                f"AGENTS.md content exceeds {MAX_AGENTS_MD_SIZE} chars, truncating"
+            )
+            # Truncate this file's contribution to stay within limit
+            allowed = MAX_AGENTS_MD_SIZE - (total_size - len(text))
+            if allowed > 0:
+                contents.append(text[:allowed])
+            break
+
+        contents.append(text)
+
+    return "\n\n---\n\n".join(contents)

--- a/packages/tyler/tyler/models/skill.py
+++ b/packages/tyler/tyler/models/skill.py
@@ -1,0 +1,205 @@
+"""Skill model and manager for Agent Skills support.
+
+Implements the Agent Skills open format (https://agentskills.io/specification).
+Skills are directories containing a SKILL.md file with YAML frontmatter
+(name, description) and markdown instructions. Skills are progressively
+disclosed - only metadata appears in the system prompt, and full instructions
+are loaded on-demand via the activate_skill tool.
+"""
+import re
+import yaml
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Tuple, Optional
+
+from tyler.utils.tool_runner import tool_runner
+
+logger = logging.getLogger(__name__)
+
+# Validation constraints per the Agent Skills spec
+MAX_NAME_LENGTH = 64
+MAX_DESCRIPTION_LENGTH = 1024
+NAME_PATTERN = re.compile(r'^[a-z0-9][a-z0-9-]*$')
+
+
+@dataclass
+class Skill:
+    """Represents a loaded skill from a SKILL.md file."""
+    name: str
+    description: str
+    path: Path
+    content: str
+    metadata: dict = field(default_factory=dict)
+
+
+class SkillManager:
+    """Manages skill discovery, loading, and tool registration."""
+
+    def __init__(self):
+        self._skills: Dict[str, Skill] = {}
+
+    def load_skills(self, skill_paths: List[str]) -> Tuple[List[Skill], List[Dict]]:
+        """Load skills from directories and register the activate_skill tool.
+
+        Args:
+            skill_paths: List of paths to skill directories containing SKILL.md files.
+
+        Returns:
+            Tuple of (loaded skills list, tool definitions for _processed_tools).
+
+        Raises:
+            ValueError: If a skill has invalid name/description or if activate_skill
+                        tool name conflicts with an existing tool.
+        """
+        skills = []
+        for path_str in skill_paths:
+            path = Path(path_str).expanduser().resolve()
+            skill_md = path / "SKILL.md"
+
+            if not skill_md.exists():
+                logger.warning(f"No SKILL.md found in {path}, skipping")
+                continue
+
+            skill = self._parse_skill(skill_md, path)
+            self._validate_skill(skill)
+            skills.append(skill)
+            self._skills[skill.name] = skill
+
+        if not skills:
+            return [], []
+
+        # Check for tool name collision before registering
+        if "activate_skill" in tool_runner.tools:
+            raise ValueError(
+                "Cannot register skill tools: a tool named 'activate_skill' is already "
+                "registered. Please rename your tool to avoid collision."
+            )
+
+        # Build the activate_skill tool
+        tool_def = self._build_activate_skill_definition()
+        implementation = self._build_activate_skill_implementation()
+
+        tool_runner.register_tool(
+            name="activate_skill",
+            implementation=implementation,
+            definition=tool_def["function"],
+        )
+
+        # Register tool attributes
+        tool_runner.register_tool_attributes(
+            "activate_skill", {"source": "skills"}
+        )
+
+        tool_definitions = [tool_def]
+        return skills, tool_definitions
+
+    def _parse_skill(self, skill_md: Path, directory: Path) -> Skill:
+        """Parse a SKILL.md file into a Skill object."""
+        raw = skill_md.read_text(encoding="utf-8")
+
+        # Split on --- markers to extract YAML frontmatter
+        parts = raw.split("---", 2)
+        if len(parts) < 3:
+            raise ValueError(
+                f"SKILL.md in {directory} is missing YAML frontmatter "
+                f"(expected --- delimiters)"
+            )
+
+        frontmatter_str = parts[1].strip()
+        body = parts[2].strip()
+
+        try:
+            frontmatter = yaml.safe_load(frontmatter_str) or {}
+        except yaml.YAMLError as e:
+            raise ValueError(
+                f"Invalid YAML frontmatter in {skill_md}: {e}"
+            )
+
+        name = frontmatter.get("name")
+        description = frontmatter.get("description")
+
+        if not name:
+            raise ValueError(f"SKILL.md in {directory} is missing 'name' in frontmatter")
+        if not description:
+            raise ValueError(f"SKILL.md in {directory} is missing 'description' in frontmatter")
+
+        # Extract remaining metadata (everything except name/description)
+        metadata = {k: v for k, v in frontmatter.items() if k not in ("name", "description")}
+
+        return Skill(
+            name=name,
+            description=description,
+            path=directory,
+            content=body,
+            metadata=metadata,
+        )
+
+    def _validate_skill(self, skill: Skill) -> None:
+        """Validate skill name and description per the Agent Skills spec."""
+        if not NAME_PATTERN.match(skill.name):
+            raise ValueError(
+                f"Skill name '{skill.name}' is invalid. Must be lowercase letters, "
+                f"numbers, and hyphens, starting with a letter or number."
+            )
+        if len(skill.name) > MAX_NAME_LENGTH:
+            raise ValueError(
+                f"Skill name '{skill.name}' exceeds {MAX_NAME_LENGTH} characters."
+            )
+        if len(skill.description) > MAX_DESCRIPTION_LENGTH:
+            raise ValueError(
+                f"Skill description for '{skill.name}' exceeds "
+                f"{MAX_DESCRIPTION_LENGTH} characters."
+            )
+
+    def _build_activate_skill_definition(self) -> Dict:
+        """Build the OpenAI-compatible tool definition for activate_skill."""
+        available = ", ".join(sorted(self._skills.keys()))
+        return {
+            "type": "function",
+            "function": {
+                "name": "activate_skill",
+                "description": (
+                    "Activate a skill to load its full instructions. "
+                    "Use when a task matches an available skill."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "description": f"The name of the skill to activate. Available: {available}",
+                        }
+                    },
+                    "required": ["name"],
+                },
+            },
+        }
+
+    def _build_activate_skill_implementation(self):
+        """Build the activate_skill tool implementation function."""
+        skills = self._skills
+
+        async def activate_skill(name: str) -> str:
+            """Load and return the full instructions for a skill."""
+            skill = skills.get(name)
+            if skill is None:
+                available = ", ".join(sorted(skills.keys()))
+                return f"Unknown skill '{name}'. Available skills: {available}"
+            return skill.content
+
+        return activate_skill
+
+    def format_skills_prompt(self, skills: List[Skill]) -> str:
+        """Format the skills metadata block for system prompt injection.
+
+        Args:
+            skills: List of loaded Skill objects.
+
+        Returns:
+            Formatted string for inclusion in the system prompt.
+        """
+        lines = []
+        for skill in skills:
+            lines.append(f"- `{skill.name}`: {skill.description}")
+        return "\n".join(lines)


### PR DESCRIPTION
## Summary

- Add support for the [Agent Skills](https://agentskills.io/specification) open format — progressively disclosed skill instructions loaded on-demand via `activate_skill` tool
- Add support for the [AGENTS.md](https://agents.md) open standard — project-level instruction files eagerly loaded into the system prompt at init time

### Agent Skills

Skills are directories containing a `SKILL.md` file with YAML frontmatter (name, description) and markdown instructions. Only metadata appears in the system prompt; full instructions are loaded on-demand when the agent calls `activate_skill`.

- **`tyler/models/skill.py`** (new) — `Skill` dataclass, `SkillManager` with frontmatter parsing, validation, and `activate_skill` tool registration
- **`tyler/models/agent.py`** — Added `skills` field, skill loading in `_initialize_helpers()`, `<available_skills>` block in system prompt, `_regenerate_system_prompt()` centralization
- **`tyler/config.py`** — Added `_process_skills_list()` for YAML config path resolution
- **`tests/models/test_agent_skills.py`** (new) — 30 tests covering loading, validation, activation, prompt injection, config, MCP survival, and no-regression
- **`examples/108_skills.py`** + sample SKILL.md files

### AGENTS.md

AGENTS.md files provide project-level guidelines that are eagerly loaded into a `<project_instructions>` block in the system prompt. Supports `None` (default/disabled), `True` (auto-discover from CWD upward), `False` (disabled), `str` (explicit path), or `List[str]` (multiple paths).

- **`tyler/models/agents_md.py`** (new) — `discover_agents_md()` walks directories upward; `load_agents_md()` handles all config variants with 100K size guard
- **`tyler/models/agent.py`** — Added `agents_md` field, `_agents_md_content` private attr, `<project_instructions>` block before `<available_skills>`
- **`tyler/config.py`** — Added `_resolve_config_dir_path()` shared helper (used by both skills and agents_md), `_process_agents_md()` for YAML config
- **`tests/models/test_agents_md.py`** (new) — 27 tests covering discovery, loading, prompt injection, MCP survival, config, and no-regression
- **`examples/109_agents_md.py`** + sample AGENTS.md

### System prompt structure (after changes)

```
<agent_overview>        — purpose, notes
<operational_routine>   — behavioral instructions
<tool_usage_guidelines> — available tools
<file_handling_instructions>
<project_instructions>  — AGENTS.md content (new)
<available_skills>      — skill metadata (new)
```

## Test plan

- [x] All 57 new tests pass (30 skills + 27 agents_md)
- [x] Skills and AGENTS.md coexist correctly in system prompt
- [x] Both survive `connect_mcp()` prompt regeneration
- [x] No regression — agents without skills/agents_md work unchanged
- [ ] Manual verification with example scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)