### PR TITLE
feat: add direnv support for per-repo env vars

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,9 @@
+# Load project env vars
+# Option 1: Central location (recommended for worktrees)
+#   Create ~/.env/slide.env with your values
+# Option 2: Local .env file in repo root (gitignored)
+if [ -f ~/.env/slide.env ]; then
+  dotenv ~/.env/slide.env
+elif [ -f .env ]; then
+  dotenv .env
+fi


### PR DESCRIPTION
Add direnv configuration for managing environment variables on a per-repo basis, supporting git worktrees.

The `.envrc` file sources env vars from `~/.env/slide.env` (shared across worktrees) with a fallback to a local `.env` file for other contributors. This eliminates the need to maintain env vars in global shell configuration and makes setup seamless for new worktrees.

🤖 Generated with Claude Code