### PR TITLE
Release v6.4.0

### DIFF
--- a/packages/lye/lye/__init__.py
+++ b/packages/lye/lye/__init__.py
@@ -1,7 +1,7 @@
 """
 Lye - Tools package for Tyler
 """
-__version__ = "6.3.0"
+__version__ = "6.4.0"
 
 import importlib
 import sys

--- a/packages/lye/pyproject.toml
+++ b/packages/lye/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slide-lye"
-version = "6.3.0"
+version = "6.4.0"
 description = "Lye - Tools package for Tyler AI framework"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/narrator/narrator/__init__.py
+++ b/packages/narrator/narrator/__init__.py
@@ -8,7 +8,7 @@ from .models.thread import Thread
 from .models.message import Message
 from .models.attachment import Attachment
 
-__version__ = "6.3.0"
+__version__ = "6.4.0"
 __all__ = [
     "ThreadStore",
     "FileStore", 

--- a/packages/narrator/pyproject.toml
+++ b/packages/narrator/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slide-narrator"
-version = "6.3.0"
+version = "6.4.0"
 description = "Thread and file storage components for conversational AI - the companion to Tyler AI framework"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/space-monkey/pyproject.toml
+++ b/packages/space-monkey/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slide-space-monkey"
-version = "6.3.0"
+version = "6.4.0"
 description = "A simple, powerful way to deploy Tyler AI agents as Slack agents"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -26,8 +26,8 @@ classifiers = [
 ]
 dependencies = [
     # Core Tyler ecosystem packages
-    "slide-tyler>=6.3.0",
-    "slide-narrator>=6.3.0",
+    "slide-tyler>=6.4.0",
+    "slide-narrator>=6.4.0",
     # Slack integration
     "slack-bolt>=1.23.0",
     # Web framework

--- a/packages/space-monkey/space_monkey/__init__.py
+++ b/packages/space-monkey/space_monkey/__init__.py
@@ -14,7 +14,7 @@ from .message_classifier_prompt import format_classifier_prompt
 from .utils import get_logger
 
 # Version
-__version__ = "6.3.0"
+__version__ = "6.4.0"
 
 # Main exports
 __all__ = [

--- a/packages/tyler/CHANGELOG.md
+++ b/packages/tyler/CHANGELOG.md
@@ -1,3 +1,25 @@
+## [tyler-v6.4.0] - 2026-06-03
+
+### 🚀 Features
+
+- Add execution details and Weave Agents tracing
+- Add Agent Skills support for progressive skill disclosure
+- Add skills example with sample SKILL.md files
+- Add AGENTS.md support for project-level instructions
+
+### 🐛 Bug Fixes
+
+- Preserve AgentResult positional order
+- Address AgentResult review findings
+- Preserve skills state during connect_mcp() prompt regeneration
+- Address code review findings for AGENTS.md support
+- Skip oversized AGENTS.md files before reading into memory
+
+### 📚 Documentation
+
+- Make streaming the primary agent example
+- Align agent API docs with streaming-first usage
+- Add Skills and AGENTS.md documentation
 ## [tyler-v6.3.0] - 2026-01-22
 
 ### 🚀 Features

--- a/packages/tyler/pyproject.toml
+++ b/packages/tyler/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "slide-tyler"
-version = "6.3.0"
+version = "6.4.0"
 description = "Tyler: A development kit for manifesting AI agents with a complete lack of conventional limitations"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -30,8 +30,8 @@ dependencies = [
     "pandas>=2.2.3",
     "pypdf>=5.3.0",
     "pillow>=11.0.0",
-    "slide-narrator>=6.3.0",
-    "slide-lye>=6.3.0",
+    "slide-narrator>=6.4.0",
+    "slide-lye>=6.4.0",
     "aiohttp>=3.11.11",
     "httpx>=0.27.2",
     "requests>=2.32.3",

--- a/packages/tyler/tyler/__init__.py
+++ b/packages/tyler/tyler/__init__.py
@@ -1,6 +1,6 @@
 """Tyler - A development kit for AI agents with a complete lack of conventional limitations"""
 
-__version__ = "6.3.0"
+__version__ = "6.4.0"
 
 from tyler.utils.logging import get_logger
 from tyler.models.agent import Agent

--- a/uv.lock
+++ b/uv.lock
@@ -6697,7 +6697,7 @@ wheels = [
 
 [[package]]
 name = "slide-lye"
-version = "6.3.0"
+version = "6.4.0"
 source = { editable = "packages/lye" }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -6753,7 +6753,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "slide-narrator"
-version = "6.3.0"
+version = "6.4.0"
 source = { editable = "packages/narrator" }
 dependencies = [
     { name = "aiosqlite" },
@@ -6797,7 +6797,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "slide-space-monkey"
-version = "6.3.0"
+version = "6.4.0"
 source = { editable = "packages/space-monkey" }
 dependencies = [
     { name = "fastapi" },
@@ -6843,7 +6843,7 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "slide-tyler"
-version = "6.3.0"
+version = "6.4.0"
 source = { editable = "packages/tyler" }
 dependencies = [
     { name = "a2a-sdk" },


### PR DESCRIPTION
## Unified Release v6.4.0

This PR prepares the synchronized Slide package release for v6.4.0 after PR #128.

### Packages Updated
- slide-tyler: 6.3.0 -> 6.4.0
- slide-narrator: 6.3.0 -> 6.4.0
- slide-space-monkey: 6.3.0 -> 6.4.0
- slide-lye: 6.3.0 -> 6.4.0

### Changes
- Bumped all package versions and `__version__` exports to 6.4.0
- Updated Tyler and Space Monkey internal minimum constraints to >=6.4.0
- Updated `uv.lock` workspace package versions
- Added Tyler changelog entries for PR #128 and unreleased Tyler changes since v6.3.0

### Verification
```bash
uv run pytest packages/tyler/tests/
uv run python -c "import tyler, narrator, lye, space_monkey; print(tyler.__version__, narrator.__version__, lye.__version__, space_monkey.__version__)"
git diff --check
```
