### PR TITLE
Refresh Tyler agent instruction loading

### DIFF
--- a/directive/specs/agent-instructions-refresh/impact.md
+++ b/directive/specs/agent-instructions-refresh/impact.md
@@ -1,0 +1,25 @@
+# Impact Analysis — Agent Instructions Refresh
+
+## Modules/packages likely touched
+- `packages/tyler/tyler/models/agent.py`
+- `packages/tyler/tyler/models/agents_md.py`
+- `packages/tyler/tyler/models/completion_handler.py`
+- `packages/tyler/tyler/models/skill.py`
+- `packages/tyler/tyler/cli/chat.py`
+- Tyler tests, docs, and config examples
+
+## Contracts to update (APIs, events, schemas, migrations)
+- `Agent.agents_md` default behavior changes from disabled to auto-discovery.
+- New `Agent.agents_md_base_dir` config field for deterministic discovery.
+- New `Agent.instruction_role` / `CompletionHandler.instruction_role` field with values `system` or `developer`.
+- No database migrations, event schema changes, or external API changes.
+
+## Risks
+- Security: AGENTS.md auto-discovery can load local project instructions unexpectedly unless disabled.
+- Performance/Availability: prompt size can increase, but existing AGENTS.md size guards remain.
+- Data integrity: no persisted data model changes.
+
+## Observability needs
+- Logs: keep existing warnings for missing, unreadable, or oversized AGENTS.md files.
+- Metrics: no new metrics required.
+- Alerts: no new alerts required.

--- a/directive/specs/agent-instructions-refresh/spec.md
+++ b/directive/specs/agent-instructions-refresh/spec.md
@@ -1,0 +1,54 @@
+# Spec (per PR)
+
+**Feature name**: Agent Instructions Refresh
+**One-line summary**: Keep Tyler agent project instructions current and reliably delivered to model completions.
+
+---
+
+## Problem
+Tyler supports AGENTS.md and SKILL.md, but AGENTS.md currently requires explicit opt-in and the CLI can regenerate system messages without the configured project instructions or skill metadata. This makes project guidance easy to miss even when the agent itself is configured correctly.
+
+## Goal
+Tyler should auto-discover AGENTS.md by default, keep skills explicit and progressively disclosed, and send the generated instruction prompt consistently through LiteLLM chat-completion calls.
+
+## Success Criteria
+- [ ] Default `Agent()` discovers AGENTS.md from the current working directory upward.
+- [ ] `agents_md=False` and `agents_md=None` explicitly disable AGENTS.md loading.
+- [ ] Tyler chat CLI uses the same generated instruction prompt as core agent execution.
+- [ ] Optional `instruction_role` controls whether the instruction message is sent as `system` or `developer`.
+- [ ] Existing explicit AGENTS.md paths, skills, tools, streaming, and structured output continue to work.
+
+## User Story
+As a Tyler user, I want project-level and skill instructions to be passed to the underlying model consistently, so that agents follow the right workspace guidance without manual prompt wiring.
+
+## Flow / States
+An agent is created from Python or config. If AGENTS.md loading is not explicitly disabled, Tyler discovers applicable AGENTS.md files, builds one canonical instruction prompt, and uses that prompt for CLI threads and all model completions. If skills are configured, only skill metadata is included until the model calls `activate_skill`.
+
+Edge case: if a user explicitly passes `agents_md=False` or `agents_md=None`, Tyler does not load any AGENTS.md content.
+
+## UX Links
+- Designs: n/a
+- Prototype: n/a
+- Copy/Content: docs/guides/skills.mdx and tyler config template
+
+## Requirements
+- Must auto-discover AGENTS.md by default.
+- Must preserve explicit AGENTS.md path/list behavior.
+- Must allow explicit disabling with `agents_md=False` or `agents_md=None`.
+- Must keep `SKILL.md` as the canonical skill filename.
+- Must keep skills explicit and progressively disclosed.
+- Must keep LiteLLM chat completions as the default model transport.
+- Must make CLI system messages use the same prompt as core execution.
+
+## Acceptance Criteria
+- Given an AGENTS.md in the current directory, when `Agent()` is constructed without `agents_md`, then `_system_prompt` includes the AGENTS.md content.
+- Given `agents_md=False` or `agents_md=None`, when `Agent()` is constructed, then `_system_prompt` does not include `<project_instructions>`.
+- Given a config file with `agents_md: true`, when `Agent.from_config()` is used from another working directory, then discovery starts from the config file directory.
+- Given skills are configured, when `activate_skill` is called, then the tool result includes both the skill root path and the skill instructions.
+- Given the CLI creates or switches a thread, then its stored system message equals `agent._system_prompt`.
+- Given `instruction_role="developer"`, when Tyler builds completion params, then the first message role is `developer`.
+
+## Non-Goals
+- Add an OpenAI Responses API transport.
+- Auto-discover skills.
+- Update A2A server/adapter metadata.

--- a/directive/specs/agent-instructions-refresh/tdr.md
+++ b/directive/specs/agent-instructions-refresh/tdr.md
@@ -1,0 +1,82 @@
+# Technical Design Review (TDR) — Agent Instructions Refresh
+
+**Author**: Codex
+**Date**: 2026-06-03
+**Links**: Spec (`/directive/specs/agent-instructions-refresh/spec.md`), Impact (`/directive/specs/agent-instructions-refresh/impact.md`)
+
+---
+
+## 1. Summary
+Tyler will load AGENTS.md by default, keep SKILL.md explicit and progressively disclosed, and use one canonical instruction prompt for core execution and CLI threads. LiteLLM chat completions remain the only model transport for this change.
+
+## 2. Decision Drivers & Non-Goals
+- Drivers: predictable project instruction delivery, provider-compatible LiteLLM parameters, minimal interface churn.
+- Non-Goals: OpenAI Responses API support, automatic skill discovery, A2A metadata updates.
+
+## 3. Current State — Codebase Map
+- `Agent` builds `_system_prompt`, calls LiteLLM through `CompletionHandler`, and uses `_system_prompt` in non-streaming, streaming, and structured output paths.
+- `agents_md.py` discovers and loads AGENTS.md only when configured.
+- `SkillManager` loads explicit skill directories and registers `activate_skill`.
+- `ChatManager` currently regenerates system prompts and omits AGENTS.md/skill blocks.
+- Tests exist for AGENTS.md, skills, model prompt generation, and CLI thread behavior.
+
+## 4. Proposed Design
+- Make `Agent.agents_md` default to auto-discovery while preserving explicit disable with `False` or `None`.
+- Add `agents_md_base_dir` and have `Agent.from_config()` set it to the config directory when AGENTS.md discovery is enabled or omitted.
+- Add `instruction_role` to `Agent` and `CompletionHandler`; use it when prepending the canonical instruction prompt to completion messages.
+- Use `agent._system_prompt` directly in CLI create/switch flows.
+- Return activated skill output with skill root path plus instructions so relative files are actionable.
+
+## 5. Alternatives Considered
+- Keep explicit opt-in: safer but fails the requested default and leaves project instructions easier to miss.
+- Add Responses API support: broader but unnecessary for this pass and riskier across LiteLLM providers.
+- Auto-discover skills: convenient but higher security and prompt-budget risk.
+
+## 6. Data Model & Contract Changes
+- No persistent data model changes.
+- Public Agent fields added: `agents_md_base_dir`, `instruction_role`.
+- Public behavior change: default AGENTS.md auto-discovery.
+- Backward compatibility: callers can pass `agents_md=False` or `agents_md=None` to restore disabled behavior.
+
+## 7. Security, Privacy, Compliance
+- Auto-discovered files are local markdown only and retain existing size limits.
+- Secrets must not be placed in AGENTS.md; documentation should keep emphasizing env-var based secret handling.
+- No new auth or PII handling.
+
+## 8. Observability & Operations
+- Reuse existing logger warnings for skipped files.
+- No new dashboards, alerts, or runbooks.
+
+## 9. Rollout & Migration
+- Release as a normal Tyler framework behavior change.
+- Users who do not want AGENTS.md can set `agents_md: false` in config or `agents_md=False` in code.
+- Revert plan: restore default to disabled and keep the new explicit fields harmless.
+
+## 10. Test Strategy & Spec Coverage (TDD)
+- TDD commitment: add failing tests for each behavior before implementation.
+- Spec coverage:
+  - Default discovery: `test_agent_default_auto_discovers_agents_md`.
+  - Explicit disable: `test_agent_with_agents_md_none`, `test_agent_with_agents_md_false`.
+  - Config base dir: `test_from_config_agents_md_true_uses_config_dir`.
+  - Instruction role: `test_step_uses_configured_instruction_role`.
+  - Streaming/structured prompt consistency: targeted tests on captured completion messages/system prompts.
+  - Skill activation output: `test_activate_skill_returns_path_and_content`.
+  - CLI prompt consistency: create/switch thread tests.
+- CI: run the focused test command plus `cd packages/tyler && uv run pytest tests/`.
+
+## 11. Risks & Open Questions
+- Risk: default auto-discovery changes prompt content for existing callers. Mitigation: explicit disable remains available and documented.
+- Risk: `developer` role may not work with every provider. Mitigation: default remains `system`.
+- Open questions: none for this implementation.
+
+## 12. Milestones / Plan
+- Add directive docs.
+- Add failing tests.
+- Implement agents_md default/base-dir and instruction_role plumbing.
+- Update CLI prompt handling and skill activation output.
+- Update docs/config examples.
+- Run focused and Tyler package tests.
+
+---
+
+**Approval Gate**: User explicitly requested implementation of this plan.

--- a/docs/apps/tyler-cli.mdx
+++ b/docs/apps/tyler-cli.mdx
@@ -88,6 +88,11 @@ model_name: "gpt-4o"  # or any LiteLLM-compatible model
 temperature: 0.7
 max_tool_iterations: 10
 
+# Instruction Configuration
+# AGENTS.md is auto-discovered by default from this config directory upward.
+# agents_md: false
+# instruction_role: "developer"  # optional; default is "system"
+
 # Tool Configuration
 tools:
   # Built-in tool modules
@@ -102,6 +107,10 @@ tools:
   # Custom tool files
   - "./my_custom_tools.py"
   - "~/tools/special_tool.py"
+
+# Skills are explicit and each path must contain SKILL.md
+skills:
+  - "./skills/code-review"
 
 # MCP Server Configuration (optional)
 # Connect to external docs, APIs, databases

--- a/docs/guides/skills.mdx
+++ b/docs/guides/skills.mdx
@@ -8,7 +8,7 @@ Slide supports two complementary ways to inject instructions into your agent's s
 - **Skills** — progressively disclosed on-demand via the `activate_skill` tool
 - **AGENTS.md** — eagerly loaded into the system prompt at init time
 
-Both follow open standards: [Agent Skills](https://agentskills.io/specification) and [AGENTS.md](https://agents.md).
+Both follow open standards: [Open Agent Skills](https://openagentskills.dev/docs/specification) and [AGENTS.md](https://agents.md).
 
 **Code Examples**
 
@@ -38,7 +38,7 @@ Skills let you package reusable instructions that agents load only when they nee
 1. You point the agent at one or more skill directories
 2. At init time, only each skill's **name** and **description** appear in the system prompt
 3. When the agent decides it needs a skill, it calls the `activate_skill` tool
-4. The full instructions from `SKILL.md` are returned to the agent as a tool result
+4. The skill root path and full instructions from `SKILL.md` are returned to the agent as a tool result
 
 ### Creating a skill
 
@@ -130,7 +130,7 @@ AGENTS.md files provide project-level instructions that are eagerly loaded into 
 
 ### How it works
 
-1. You point the agent at one or more `AGENTS.md` files (or enable auto-discovery)
+1. Auto-discovery is enabled by default, or you point the agent at one or more `AGENTS.md` files
 2. At init time, the file contents are loaded and placed in a `<project_instructions>` block in the system prompt
 3. The agent sees these instructions on every interaction
 
@@ -159,6 +159,19 @@ Create an `AGENTS.md` file in your project root (or any directory). No special f
 
 ### Using AGENTS.md with an agent
 
+#### Default auto-discovery
+
+By default, Tyler discovers `AGENTS.md` files by walking upward from the current working directory:
+
+```python
+from tyler import Agent
+
+agent = Agent(
+    model_name="gpt-4.1",
+    purpose="A helpful coding assistant",
+)
+```
+
 #### Explicit path
 
 ```python
@@ -173,7 +186,7 @@ agent = Agent(
 
 #### Auto-discovery
 
-Set `agents_md=True` to automatically discover `AGENTS.md` files by walking upward from the current working directory to the filesystem root:
+You can also set `agents_md=True` explicitly. `Agent.from_config()` starts discovery from the config file directory when `agents_md` is omitted or set to `true`:
 
 ```python
 agent = Agent(
@@ -190,6 +203,16 @@ project-root/backend/AGENTS.md  # Backend-specific rules
 ```
 
 Files are loaded root-first, so the closest file's instructions appear last (taking natural precedence).
+
+#### Disable loading
+
+```python
+agent = Agent(
+    model_name="gpt-4.1",
+    purpose="A helpful coding assistant",
+    agents_md=False,
+)
+```
 
 #### Multiple files
 
@@ -209,16 +232,22 @@ name: "MyAgent"
 model_name: "gpt-4.1"
 purpose: "A helpful assistant"
 
-# Option 1: Auto-discover
-agents_md: true
+# Default: auto-discover from this config directory upward
+# agents_md: true
 
-# Option 2: Explicit path
+# Disable loading
+# agents_md: false
+
+# Explicit path
 # agents_md: "./AGENTS.md"
 
-# Option 3: Multiple files
+# Multiple files
 # agents_md:
 #   - "./AGENTS.md"
 #   - "./docs/coding-standards.md"
+
+# Keep "system" unless your provider supports developer messages
+instruction_role: "system"
 ```
 
 Relative paths are resolved relative to the config file's directory.

--- a/docs/introduction.mdx
+++ b/docs/introduction.mdx
@@ -57,7 +57,7 @@ Slide gives you everything you need to build, test, and deploy intelligent AI ag
 - **Persistent with conversations**: Equipped with built-in support for threads, messages, and attachments with flexible storage options (in-memory, SQLite, or PostgreSQL)
 - **Type-safe structured outputs**: Get validated Pydantic models from your agents with automatic retry on validation failure—no more manual JSON parsing
 - **Ready-to-use with tools**: Packed with built-in tools for web interaction, file handling, and browser automation—plus dependency injection via `tool_context` for custom tools
-- **Skills and project instructions**: Progressively disclose reusable [Agent Skills](https://agentskills.io/specification) on-demand, and eagerly load project-level guidelines via [AGENTS.md](https://agents.md)
+- **Skills and project instructions**: Progressively disclose reusable [Open Agent Skills](https://openagentskills.dev/docs/specification) on-demand, and eagerly load project-level guidelines via [AGENTS.md](https://agents.md)
 - **Transparent reasoning**: Access model thinking tokens to see how agents arrive at decisions
 - **Interactive CLI included**: Chat with your agents instantly using the built-in `tyler chat` command, or scaffold new projects with `tyler init`
 - **Evaluation-ready**: Equipped with a framework to test agents safely with mock tools, prebuilt LLM judges, and multi-turn conversation scenarios

--- a/packages/tyler/ARCHITECTURE.md
+++ b/packages/tyler/ARCHITECTURE.md
@@ -113,7 +113,7 @@ Handles LLM communication and response processing:
 ### SkillManager
 **Location**: `tyler/models/skill.py`
 
-Manages progressive skill disclosure following the [Agent Skills](https://agentskills.io/specification) open format:
+Manages progressive skill disclosure following the [Open Agent Skills](https://openagentskills.dev/docs/specification) format:
 - Loads `SKILL.md` files from skill directories (YAML frontmatter + markdown body)
 - Validates skill names (lowercase alphanumeric + hyphens) and descriptions
 - Registers the `activate_skill` tool with the owning agent's ToolRunner

--- a/packages/tyler/README.md
+++ b/packages/tyler/README.md
@@ -122,10 +122,11 @@ Integrates with the Model Context Protocol for:
 
 ### Skills
 
-Progressive skill disclosure following the [Agent Skills](https://agentskills.io/specification) open format:
+Progressive skill disclosure following the [Open Agent Skills](https://openagentskills.dev/docs/specification) format:
 - Skills are directories containing a `SKILL.md` file with YAML frontmatter (name, description) and markdown instructions
 - Only skill metadata (name + description) appears in the system prompt — keeping context small
 - Full instructions are loaded on-demand via the `activate_skill` tool when the agent decides it needs them
+- Activated skill output includes the skill root path so relative `scripts/`, `references/`, and `assets/` are actionable
 - Survives `connect_mcp()` prompt regeneration
 
 ```python
@@ -153,19 +154,22 @@ See `examples/108_skills.py` for a complete example.
 
 Project-level instructions following the [AGENTS.md](https://agents.md) open standard:
 - Eagerly loaded into the system prompt at init time (unlike skills which are progressively disclosed)
-- Auto-discovery walks upward from a base directory, collecting all `AGENTS.md` files (root-first ordering)
-- Supports explicit paths, lists of paths, or boolean auto-discovery
+- Auto-discovery is enabled by default and walks upward from a base directory, collecting all `AGENTS.md` files (root-first ordering)
+- Supports explicit paths, lists of paths, boolean auto-discovery, or explicit disable with `agents_md=False` / `agents_md=None`
 - Content appears in a `<project_instructions>` block in the system prompt
 
 ```python
+# Default: auto-discover from CWD upward
+agent = Agent(model_name="gpt-4.1")
+
 # Explicit path
 agent = Agent(model_name="gpt-4.1", agents_md="./AGENTS.md")
 
-# Auto-discover from CWD upward
-agent = Agent(model_name="gpt-4.1", agents_md=True)
-
 # Multiple files
 agent = Agent(model_name="gpt-4.1", agents_md=["./AGENTS.md", "./docs/AGENTS.md"])
+
+# Disable AGENTS.md loading
+agent = Agent(model_name="gpt-4.1", agents_md=False)
 ```
 
 See `examples/109_agents_md.py` and `examples/sample-project/AGENTS.md` for a complete example.
@@ -435,7 +439,9 @@ tools:
 skills:
   - "./skills/code-review"
   - "./skills/testing"
-agents_md: true  # or "./AGENTS.md" or ["./AGENTS.md", "./docs/AGENTS.md"]
+# AGENTS.md is auto-discovered by default from the config directory upward.
+# agents_md: false  # disable, or use "./AGENTS.md" / ["./AGENTS.md", "./docs/AGENTS.md"]
+instruction_role: "system"  # or "developer" for providers that support it
 mcp:
   servers:
     - name: "docs"

--- a/packages/tyler/tests/cli/test_chat_integration.py
+++ b/packages/tyler/tests/cli/test_chat_integration.py
@@ -92,3 +92,61 @@ async def test_multiple_threads_without_weave():
     # Current thread should be the most recent (thread3)
     assert manager.current_thread.id == thread3.id
 
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, {}, clear=True)
+async def test_cli_thread_creation_uses_agent_system_prompt(tmp_path):
+    """CLI thread creation stores the canonical agent prompt with AGENTS.md and skills."""
+    from tyler.cli.chat import ChatManager
+
+    agents_file = tmp_path / "AGENTS.md"
+    agents_file.write_text("CLI project instruction.")
+    skill_dir = tmp_path / "cli-skill"
+    skill_dir.mkdir()
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: cli-skill\ndescription: CLI skill metadata\n---\nCLI skill body."
+    )
+
+    manager = ChatManager()
+    await manager.initialize_agent({
+        "model_name": "gpt-4.1",
+        "purpose": "CLI test assistant",
+        "agents_md": str(agents_file),
+        "skills": [str(skill_dir)],
+    })
+
+    thread = await manager.create_thread(title="Prompt Thread")
+
+    system_message = thread.get_system_message()
+    assert system_message is not None
+    assert system_message.content == manager.agent._system_prompt
+    assert "CLI project instruction." in system_message.content
+    assert "CLI skill metadata" in system_message.content
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, {}, clear=True)
+async def test_cli_switch_thread_refreshes_agent_system_prompt(tmp_path):
+    """CLI thread switching refreshes stale system messages with the canonical prompt."""
+    from tyler.cli.chat import ChatManager
+
+    agents_file = tmp_path / "AGENTS.md"
+    agents_file.write_text("Switch project instruction.")
+
+    manager = ChatManager()
+    await manager.initialize_agent({
+        "model_name": "gpt-4.1",
+        "purpose": "CLI switch assistant",
+        "agents_md": str(agents_file),
+    })
+
+    thread = await manager.create_thread(title="Switch Thread")
+    thread.get_system_message().content = "stale prompt"
+    thread.add_message(Message(role="user", content="Persist this thread"))
+    await manager.thread_store.save(thread)
+
+    switched = await manager.switch_thread(thread.id)
+
+    assert switched is not None
+    assert switched.get_system_message().content == manager.agent._system_prompt
+    assert "Switch project instruction." in switched.get_system_message().content

--- a/packages/tyler/tests/cli/test_chat_integration.py
+++ b/packages/tyler/tests/cli/test_chat_integration.py
@@ -6,6 +6,7 @@ Tests verify that CLI works correctly with and without Weave.
 import os
 from unittest.mock import patch
 import pytest
+import yaml
 from narrator import Message
 
 
@@ -150,3 +151,30 @@ async def test_cli_switch_thread_refreshes_agent_system_prompt(tmp_path):
     assert switched is not None
     assert switched.get_system_message().content == manager.agent._system_prompt
     assert "Switch project instruction." in switched.get_system_message().content
+
+
+@pytest.mark.asyncio
+@patch.dict(os.environ, {}, clear=True)
+async def test_cli_config_discovers_agents_md_from_config_directory(tmp_path, monkeypatch):
+    """CLI config initialization discovers AGENTS.md from the config directory."""
+    from tyler.cli.chat import ChatManager
+
+    config_dir = tmp_path / "config-dir"
+    config_dir.mkdir()
+    cwd_dir = tmp_path / "cwd"
+    cwd_dir.mkdir()
+    (config_dir / "AGENTS.md").write_text("Use config directory instructions.")
+    (cwd_dir / "AGENTS.md").write_text("Wrong cwd instructions.")
+    config_file = config_dir / "tyler-chat-config.yaml"
+    config_file.write_text(yaml.dump({
+        "model_name": "gpt-4.1",
+        "purpose": "CLI config assistant",
+    }))
+    monkeypatch.chdir(cwd_dir)
+
+    manager = ChatManager()
+    await manager.initialize_agent_from_config(str(config_file))
+
+    assert manager.agent.agents_md_base_dir == str(config_dir.resolve())
+    assert "Use config directory instructions." in manager.agent._system_prompt
+    assert "Wrong cwd instructions." not in manager.agent._system_prompt

--- a/packages/tyler/tests/models/test_agent_skills.py
+++ b/packages/tyler/tests/models/test_agent_skills.py
@@ -116,6 +116,14 @@ class TestSkillValidation:
         with pytest.raises(ValueError, match="invalid"):
             manager.load_skills([str(skill_dir)])
 
+    def test_invalid_name_trailing_hyphen(self, tmp_path):
+        """Name ending with a hyphen is rejected."""
+        skill_dir = _create_skill_dir(tmp_path, name="bad-name-", description="test")
+
+        manager = SkillManager()
+        with pytest.raises(ValueError, match="invalid"):
+            manager.load_skills([str(skill_dir)])
+
     def test_invalid_name_too_long(self, tmp_path):
         """Name exceeding 64 chars is rejected."""
         long_name = "a" * 65
@@ -180,7 +188,7 @@ class TestActivateSkill:
 
     @pytest.mark.asyncio
     async def test_activate_skill_returns_content(self, tmp_path):
-        """activate_skill tool returns the full SKILL.md body."""
+        """activate_skill tool returns the skill root path and full SKILL.md body."""
         body = "# Step 1\nDo this.\n\n# Step 2\nDo that."
         skill_dir = _create_skill_dir(
             tmp_path, name="my-skill", description="A skill", body=body
@@ -191,7 +199,8 @@ class TestActivateSkill:
 
         # Execute via tool_runner
         result = await tool_runner.run_tool_async("activate_skill", {"name": "my-skill"})
-        assert result == body
+        assert f"Skill root: {skill_dir.resolve()}" in result
+        assert body in result
 
     @pytest.mark.asyncio
     async def test_activate_skill_unknown_name(self, tmp_path):

--- a/packages/tyler/tests/models/test_agent_streaming.py
+++ b/packages/tyler/tests/models/test_agent_streaming.py
@@ -92,6 +92,38 @@ async def async_generator(chunks):
     for chunk in chunks:
         yield chunk
 
+
+@pytest.mark.asyncio
+async def test_streaming_completion_uses_canonical_instruction_prompt(tmp_path):
+    """Streaming completion params use agent._system_prompt and instruction_role."""
+    agents_file = tmp_path / "AGENTS.md"
+    agents_file.write_text("Streaming project rule.")
+    agent = Agent(
+        model_name="gpt-4.1",
+        purpose="test streaming",
+        agents_md=str(agents_file),
+        instruction_role="developer",
+    )
+    thread = Thread()
+    thread.add_message(Message(role="user", content="Hello"))
+    captured_params = {}
+
+    async def fake_get_completion(**completion_params):
+        captured_params.update(completion_params)
+        return async_generator([])
+
+    agent._get_completion = fake_get_completion
+
+    await agent._get_streaming_completion(thread)
+
+    first_message = captured_params["messages"][0]
+    assert first_message == {
+        "role": "developer",
+        "content": agent._system_prompt,
+    }
+    assert "Streaming project rule." in first_message["content"]
+
+
 @pytest.mark.asyncio
 async def test_stream_basic_response():
     """Test streaming with basic response (no tool calls)"""

--- a/packages/tyler/tests/models/test_agents_md.py
+++ b/packages/tyler/tests/models/test_agents_md.py
@@ -6,8 +6,10 @@ YAML config processing, and no-regression scenarios.
 import pytest
 import yaml
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from narrator import Thread, Message
 from tyler import Agent
 from tyler.models.agents_md import discover_agents_md, load_agents_md, MAX_AGENTS_MD_SIZE
 from tyler.config import load_config
@@ -90,8 +92,16 @@ class TestDiscovery:
 class TestLoading:
     """Test load_agents_md with various config variants."""
 
+    def test_load_default_auto_discovers(self, tmp_path):
+        """Omitting agents_md triggers auto-discovery from base_dir."""
+        (tmp_path / "AGENTS.md").write_text("Default auto-discovered content")
+
+        result = load_agents_md(base_dir=tmp_path)
+
+        assert "Default auto-discovered content" in result
+
     def test_load_none_returns_empty(self):
-        """agents_md=None returns empty string."""
+        """agents_md=None explicitly disables loading."""
         assert load_agents_md(None) == ""
 
     def test_load_false_returns_empty(self):
@@ -170,6 +180,17 @@ class TestLoading:
 class TestSystemPromptInjection:
     """Test that AGENTS.md content appears in the system prompt."""
 
+    def test_agent_default_auto_discovers_agents_md(self, tmp_path, monkeypatch):
+        """Agent without agents_md config auto-discovers AGENTS.md from cwd."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("# Project Rules\nDefault discovery works.")
+        monkeypatch.chdir(tmp_path)
+
+        agent = Agent(model_name="gpt-4.1", purpose="test")
+
+        assert "<project_instructions>" in agent._system_prompt
+        assert "Default discovery works." in agent._system_prompt
+
     def test_agents_md_in_system_prompt(self, tmp_path):
         """System prompt includes <project_instructions> block."""
         agents_file = tmp_path / "AGENTS.md"
@@ -187,7 +208,7 @@ class TestSystemPromptInjection:
 
     def test_no_agents_md_no_block(self):
         """Agent with agents_md=None has no <project_instructions> block."""
-        agent = Agent(model_name="gpt-4.1", purpose="test")
+        agent = Agent(model_name="gpt-4.1", purpose="test", agents_md=None)
 
         assert "<project_instructions>" not in agent._system_prompt
 
@@ -239,6 +260,50 @@ class TestSystemPromptInjection:
         pi_pos = agent._system_prompt.index("<project_instructions>")
         as_pos = agent._system_prompt.index("<available_skills>")
         assert pi_pos < as_pos
+
+    @pytest.mark.asyncio
+    async def test_step_uses_configured_instruction_role_and_prompt(self, tmp_path):
+        """Completion params include the configured instruction role and full prompt."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Completion project rule.")
+
+        skill_dir = tmp_path / "completion-skill"
+        skill_dir.mkdir()
+        frontmatter = {"name": "completion-skill", "description": "Completion skill metadata"}
+        (skill_dir / "SKILL.md").write_text(
+            f"---\n{yaml.dump(frontmatter)}---\nSkill body."
+        )
+
+        agent = Agent(
+            model_name="gpt-4.1",
+            purpose="test",
+            instruction_role="developer",
+            agents_md=str(agents_file),
+            skills=[str(skill_dir)],
+        )
+        thread = Thread()
+        thread.add_message(Message(role="user", content="Hello"))
+        captured_params = {}
+
+        async def fake_get_completion(**completion_params):
+            captured_params.update(completion_params)
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(content="Done", tool_calls=None)
+                    )
+                ]
+            )
+
+        agent._get_completion = fake_get_completion
+
+        await agent.step(thread)
+
+        first_message = captured_params["messages"][0]
+        assert first_message["role"] == "developer"
+        assert "Completion project rule." in first_message["content"]
+        assert "<available_skills>" in first_message["content"]
+        assert "Completion skill metadata" in first_message["content"]
 
 
 class TestSurvivesConnectMcp:
@@ -345,6 +410,24 @@ class TestYamlConfig:
 
         assert result["agents_md"] is True
 
+    def test_from_config_agents_md_true_uses_config_dir(self, tmp_path, monkeypatch):
+        """Agent.from_config discovers AGENTS.md from the config file directory."""
+        config_dir = tmp_path / "config-dir"
+        config_dir.mkdir()
+        other_dir = tmp_path / "other"
+        other_dir.mkdir()
+        (config_dir / "AGENTS.md").write_text("Config directory instructions")
+        (other_dir / "AGENTS.md").write_text("Wrong cwd instructions")
+        config_file = config_dir / "config.yaml"
+        config_file.write_text(yaml.dump({"agents_md": True}))
+        monkeypatch.chdir(other_dir)
+
+        agent = Agent.from_config(str(config_file))
+
+        assert agent.agents_md_base_dir == str(config_dir.resolve())
+        assert "Config directory instructions" in agent._system_prompt
+        assert "Wrong cwd instructions" not in agent._system_prompt
+
     def test_agents_md_disabled_in_config(self, tmp_path):
         """agents_md=false in config passes through as False."""
         config_file = tmp_path / "config.yaml"
@@ -367,10 +450,11 @@ class TestYamlConfig:
 
 
 class TestNoRegression:
-    """Test that agents without agents_md work normally."""
+    """Test that agents without matching AGENTS.md work normally."""
 
-    def test_agent_default_no_project_instructions(self):
-        """Default agent has no <project_instructions> block."""
+    def test_agent_default_no_project_instructions_when_none_found(self, tmp_path, monkeypatch):
+        """Default agent has no <project_instructions> block when no file is found."""
+        monkeypatch.chdir(tmp_path)
         agent = Agent(model_name="gpt-4.1", purpose="test")
 
         assert "<project_instructions>" not in agent._system_prompt

--- a/packages/tyler/tests/models/test_execution_refactor_weave_agents.py
+++ b/packages/tyler/tests/models/test_execution_refactor_weave_agents.py
@@ -197,7 +197,8 @@ async def test_skill_tools_register_on_owning_agent_runner(tmp_path):
     result = await agent._tool_runner.run_tool_async(
         "activate_skill", {"name": "summary-skill"}
     )
-    assert result == "Use bullets."
+    assert f"Skill root: {skill_dir.resolve()}" in result
+    assert "Use bullets." in result
 
 
 @pytest.mark.asyncio

--- a/packages/tyler/tests/test_structured_output.py
+++ b/packages/tyler/tests/test_structured_output.py
@@ -471,6 +471,34 @@ class TestStructuredOutputWithTools:
             assert len(captured_tool_choice) > 0
             assert captured_tool_choice[0] == "required"
 
+    @pytest.mark.asyncio
+    async def test_structured_output_uses_canonical_instruction_prompt(self, tmp_path, thread):
+        """Structured output appends its instruction to the canonical prompt."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("Structured project rule.")
+        agent = Agent(
+            name="test-agent",
+            model_name="gpt-4.1",
+            purpose="Test structured prompt",
+            agents_md=str(agents_file),
+        )
+
+        valid_data = {"invoice_id": "INV-001", "total": 50.0, "items": ["Test"], "paid": True}
+        output_response = create_output_tool_response("Invoice", valid_data)
+        captured_system_prompt = []
+
+        async def capture_step(thread_arg, stream=False, tools=None, system_prompt=None, tool_choice=None):
+            captured_system_prompt.append(system_prompt)
+            return (output_response, {"usage": {}})
+
+        with patch.object(agent, 'step', side_effect=capture_step):
+            await agent.run(thread, response_type=Invoice)
+
+        assert captured_system_prompt
+        assert captured_system_prompt[0].startswith(agent._system_prompt)
+        assert "Structured project rule." in captured_system_prompt[0]
+        assert "structured_output_instruction" in captured_system_prompt[0]
+
 
 class TestStructuredOutputValidation:
     """Tests for validation and edge cases."""
@@ -669,4 +697,3 @@ class TestRetryConfig:
         config = RetryConfig()
         with pytest.raises(ValidationError):
             config.max_retries = 5
-

--- a/packages/tyler/tyler-chat-config-wandb.yaml
+++ b/packages/tyler/tyler-chat-config-wandb.yaml
@@ -43,12 +43,21 @@ max_tool_iterations: 10
 # DeepSeek models support thinking tokens when this is enabled
 reasoning: "low"  # Options: "low", "medium", "high" or dict for advanced config
 
+# Instruction Configuration
+# AGENTS.md is auto-discovered by default from this config directory upward.
+# Set agents_md: false to disable. Keep "system" unless the provider supports developer messages.
+instruction_role: "system"
+
 # Tool Configuration
 tools:
   - "web"
   - "slack"
   - "notion"
   - "command_line"
+
+# Skills are explicit and progressively disclosed via activate_skill.
+# skills:
+#   - "./skills/code-review"
 
 # MCP (Model Context Protocol) Server Configuration
 # Connect to external documentation, APIs, databases via MCP servers
@@ -59,4 +68,3 @@ tools:
 #       transport: streamablehttp  # Mintlify uses streamablehttp transport
 #       url: https://slide.mintlify.app/mcp
 #       # Tools will be available as: slide_docs_SearchSlideFramework, etc.
-

--- a/packages/tyler/tyler-chat-config.yaml
+++ b/packages/tyler/tyler-chat-config.yaml
@@ -22,6 +22,13 @@ max_tool_iterations: 10
 # Enables thinking tokens to be displayed in the CLI
 reasoning: "low"  # Options: "low", "medium", "high" or dict for advanced config
 
+# Instruction Configuration
+# AGENTS.md is auto-discovered by default from this config directory upward.
+# Set agents_md: false to disable, or provide explicit path(s).
+# agents_md: false
+# agents_md: "./AGENTS.md"
+# instruction_role: "developer"  # Optional; default is "system"
+
 # Tool Configuration
 # List of tools to load. Can be:
 #   - Built-in tool module names (e.g., "web", "slack")
@@ -35,6 +42,12 @@ tools:
   - "notion"        # Notion integration tools
   - "command_line"  # System command execution tools
   # - "./my_tools.py"  # Example custom tools (uncomment to use)
+
+# Skills are explicit and progressively disclosed via activate_skill.
+# Each path must contain a SKILL.md file.
+# skills:
+#   - "./skills/code-review"
+#   - "./skills/testing"
 
 # MCP (Model Context Protocol) Server Configuration
 # Connect to external documentation, APIs, databases via MCP servers

--- a/packages/tyler/tyler/cli/chat.py
+++ b/packages/tyler/tyler/cli/chat.py
@@ -123,7 +123,6 @@ for logger_name in noisy_libraries:
 # Import Tyler modules with suppressed output
 with suppress_output():
     from tyler import Agent, Thread, Message, ThreadStore
-    from tyler.config import load_config, load_custom_tool
     from tyler.models.execution import ExecutionEvent, EventType
 
 # Initialize rich console
@@ -150,6 +149,20 @@ class ChatManager:
         # Create agent with provided config, suppressing initialization errors
         with suppress_output():
             self.agent = Agent(**config)
+
+        await self._connect_mcp_servers()
+
+    async def initialize_agent_from_config(self, config_path: Optional[str] = None) -> None:
+        """Initialize the agent from a Tyler config file."""
+        with suppress_output():
+            self.agent = Agent.from_config(config_path)
+
+        await self._connect_mcp_servers()
+
+    async def _connect_mcp_servers(self) -> None:
+        """Auto-connect configured MCP servers for the current agent."""
+        if self.agent is None:
+            return
         
         # Auto-connect to MCP servers if configured
         if self.agent.mcp:
@@ -512,12 +525,9 @@ def _main_inner(config: Optional[str], title: Optional[str]):
     async def async_main():
         chat_manager = None  # Initialize before try block
         try:
-            # Load configuration
-            config_data = load_config(config)
-            
             # Initialize chat manager
             chat_manager = ChatManager()
-            await chat_manager.initialize_agent(config_data)
+            await chat_manager.initialize_agent_from_config(config)
             
             # Create initial thread
             await chat_manager.create_thread(title=title)

--- a/packages/tyler/tyler/cli/chat.py
+++ b/packages/tyler/tyler/cli/chat.py
@@ -185,6 +185,16 @@ class ChatManager:
             except Exception as e:
                 console.print(f"[red]✗ Failed to connect to MCP servers: {e}[/]")
                 raise  # Fail startup if MCP configured but broken
+
+    def _ensure_agent_system_prompt(self, thread: Thread) -> None:
+        """Ensure a thread carries the current agent system prompt in memory."""
+        if not self.agent:
+            return
+        system_message = thread.get_system_message()
+        if system_message is None:
+            thread.add_message(Message(role="system", content=self.agent._system_prompt))
+        else:
+            system_message.content = self.agent._system_prompt
         
     async def create_thread(self, 
                           title: Optional[str] = None,
@@ -204,19 +214,9 @@ class ChatManager:
             source=source
         )
         
-        # Add the agent's system prompt as the first message
-        if self.agent:
-            system_prompt = self.agent._prompt.system_prompt(
-                self.agent.purpose,
-                self.agent.name,
-                self.agent.model_name,
-                tools=self.agent._processed_tools,
-                notes=self.agent.notes
-            )
-            # Add system message if thread is empty
-            if not thread.messages:
-                system_message = Message(role="system", content=system_prompt)
-                thread.add_message(system_message)
+        # Add the agent's canonical system prompt as the first message.
+        if self.agent and not thread.messages:
+            self._ensure_agent_system_prompt(thread)
             
         await self.thread_store.save(thread)
         self.current_thread = thread
@@ -245,38 +245,26 @@ class ChatManager:
                     
                     # Ensure thread has correct system prompt
                     if self.agent:
-                        system_prompt = self.agent._prompt.system_prompt(
-                            self.agent.purpose,
-                            self.agent.name,
-                            self.agent.model_name,
-                            tools=self.agent._processed_tools,
-                            notes=self.agent.notes
-                        )
-                        thread.ensure_system_prompt(system_prompt)
+                        self._ensure_agent_system_prompt(thread)
                         await self.thread_store.save(thread)
                         
                     return thread
                 else:
                     raise ValueError(f"Thread index {index} is out of range")
-        except ValueError as e:
-            # If not a valid index, try as thread ID
-            thread = await self.thread_store.get(thread_id_or_index)
-            if thread:
-                self.current_thread = thread
-                
-                # Ensure thread has correct system prompt
-                if self.agent:
-                    system_prompt = self.agent._prompt.system_prompt(
-                        self.agent.purpose,
-                        self.agent.name,
-                        self.agent.model_name,
-                        tools=self.agent._processed_tools,
-                        notes=self.agent.notes
-                    )
-                    thread.ensure_system_prompt(system_prompt)
-                    await self.thread_store.save(thread)
-                    
-            return thread
+        except ValueError:
+            pass
+
+        # If not a valid numeric index, try as thread ID.
+        thread = await self.thread_store.get(thread_id_or_index)
+        if thread:
+            self.current_thread = thread
+
+            # Ensure thread has correct system prompt
+            if self.agent:
+                self._ensure_agent_system_prompt(thread)
+                await self.thread_store.save(thread)
+
+        return thread
 
     def format_message(self, message: Message) -> Union[Panel, List[Panel]]:
         """Format a message for display"""

--- a/packages/tyler/tyler/config.py
+++ b/packages/tyler/tyler/config.py
@@ -45,6 +45,18 @@ model_name: "gpt-4.1"
 temperature: 0.7
 max_tool_iterations: 10
 
+# Instruction Configuration
+# AGENTS.md is auto-discovered by default from the config directory upward.
+# Set agents_md: false to disable, or provide explicit path(s).
+# agents_md: false
+# agents_md: "./AGENTS.md"
+# agents_md:
+#   - "./AGENTS.md"
+#   - "./docs/coding-standards.md"
+#
+# Use "developer" only for providers/models that support developer messages.
+instruction_role: "system"  # Options: "system", "developer"
+
 # Tool Configuration
 # List of tools to load. Can be:
 #   - Built-in tool module names (e.g., "web", "files")
@@ -58,6 +70,12 @@ tools:
   # - "notion"        # Notion integration tools
   # - "command_line"  # System command execution tools
   # - "./my_tools.py"  # Example custom tools (uncomment to use)
+
+# Skills are explicit and progressively disclosed via activate_skill.
+# Each path must contain a SKILL.md file.
+# skills:
+#   - "./skills/code-review"
+#   - "./skills/testing"
 
 # MCP (Model Context Protocol) Server Configuration
 # Connect to external documentation, APIs, databases via MCP servers
@@ -453,4 +471,3 @@ def _process_agents_md(agents_md: Any, config_dir: Path) -> Any:
         return resolved
 
     return agents_md
-

--- a/packages/tyler/tyler/models/agent.py
+++ b/packages/tyler/tyler/models/agent.py
@@ -428,7 +428,9 @@ class Agent(BaseModel):
     version: str = Field(default="1.0.0")
     tools: List[Union[str, Dict, Callable, types.ModuleType]] = Field(default_factory=list, description="List of tools available to the agent. Can include: 1) Direct tool function references (callables), 2) Tool module namespaces (modules like web, files), 3) Built-in tool module names (strings), 4) Custom tool definitions (dicts with 'definition', 'implementation', and optional 'attributes' keys). For module names, you can specify specific tools using 'module:tool1,tool2'.")
     skills: List[str] = Field(default_factory=list, description="List of paths to skill directories containing SKILL.md files.")
-    agents_md: Optional[Union[bool, str, List[str]]] = Field(default=None, description="AGENTS.md project instructions. None=disabled (default), True=auto-discover from CWD upward, False=disabled, str=explicit path, List[str]=multiple paths.")
+    agents_md: Optional[Union[bool, str, List[str]]] = Field(default=True, description="AGENTS.md project instructions. Default/True=auto-discover from base dir or CWD upward, None/False=disabled, str=explicit path, List[str]=multiple paths.")
+    agents_md_base_dir: Optional[str] = Field(default=None, description="Base directory for AGENTS.md auto-discovery. Defaults to current working directory.")
+    instruction_role: Literal["system", "developer"] = Field(default="system", description="Role used for the generated instruction prompt in LiteLLM chat completion messages.")
     max_tool_iterations: int = Field(default=10)
     agents: List["Agent"] = Field(default_factory=list, description="List of agents that this agent can delegate tasks to.")
     thread_store: Optional[ThreadStore] = Field(default=None, description="Thread store instance for managing conversation threads", exclude=True)
@@ -519,8 +521,11 @@ class Agent(BaseModel):
                 api_key=self.api_key,
                 extra_headers=self.extra_headers,
                 drop_params=self.drop_params,
-                reasoning=self.reasoning
+                reasoning=self.reasoning,
+                instruction_role=self.instruction_role
             )
+        elif hasattr(self.completion_handler, "instruction_role"):
+            self.completion_handler.instruction_role = self.instruction_role
         
         # Use ToolManager to register all tools and delegation
         tool_manager = ToolManager(
@@ -541,7 +546,10 @@ class Agent(BaseModel):
                 self._skills_description = skill_manager.format_skills_prompt(loaded_skills)
 
         # Load AGENTS.md project instructions
-        self._agents_md_content = load_agents_md(self.agents_md)
+        self._agents_md_content = load_agents_md(
+            self.agents_md,
+            base_dir=self.agents_md_base_dir,
+        )
 
         # Create default stores if not provided
         if self.thread_store is None:
@@ -570,6 +578,10 @@ class Agent(BaseModel):
             skills_description=self._skills_description,
             agents_md_content=self._agents_md_content
         )
+
+    def _build_instruction_message(self, content: str) -> Dict[str, str]:
+        """Build the instruction message prepended to model completion calls."""
+        return {"role": self.instruction_role, "content": content}
 
     def model_post_init(self, __context: Any) -> None:
         """Pydantic v2 hook called after model initialization.
@@ -643,16 +655,20 @@ class Agent(BaseModel):
             >>> await agent.connect_mcp()  # If MCP servers configured
             >>> result = await agent.go(thread)
         """
-        from tyler.config import load_config
+        from tyler.config import load_config, _resolve_config_path
         
         # Load config from file
         logging.getLogger(__name__).info(f"Creating agent from config: {config_path or 'auto-discovered'}")
-        config = load_config(config_path)
+        resolved_config_path = _resolve_config_path(config_path)
+        config = load_config(str(resolved_config_path))
         
         # Apply overrides (replacement semantics - dict.update replaces)
         if overrides:
             logging.getLogger(__name__).debug(f"Config overrides: {list(overrides.keys())}")
             config.update(overrides)
+
+        if config.get("agents_md", True) is True and "agents_md_base_dir" not in config:
+            config["agents_md_base_dir"] = str(resolved_config_path.parent.resolve())
         
         # Create agent using standard __init__
         return cls(**config)
@@ -866,7 +882,7 @@ class Agent(BaseModel):
         effective_system_prompt = system_prompt if system_prompt is not None else self._system_prompt
         
         # Use CompletionHandler to build parameters
-        completion_messages = [{"role": "system", "content": effective_system_prompt}] + thread_messages
+        completion_messages = [self._build_instruction_message(effective_system_prompt)] + thread_messages
         completion_params = self.completion_handler._build_completion_params(
             messages=completion_messages,
             tools=effective_tools,
@@ -1807,7 +1823,7 @@ class Agent(BaseModel):
         effective_tools = tools if tools is not None else self._processed_tools
         effective_system_prompt = system_prompt if system_prompt is not None else self._system_prompt
 
-        completion_messages = [{"role": "system", "content": effective_system_prompt}] + thread_messages
+        completion_messages = [self._build_instruction_message(effective_system_prompt)] + thread_messages
         completion_params = self.completion_handler._build_completion_params(
             messages=completion_messages,
             tools=effective_tools,

--- a/packages/tyler/tyler/models/agents_md.py
+++ b/packages/tyler/tyler/models/agents_md.py
@@ -8,12 +8,14 @@ See: https://agents.md
 """
 import logging
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 logger = logging.getLogger(__name__)
 
 # Guard against huge files
 MAX_AGENTS_MD_SIZE = 100_000
+
+_AUTO_DISCOVER = object()
 
 
 def discover_agents_md(start_dir: Union[str, Path]) -> List[Path]:
@@ -48,14 +50,15 @@ def discover_agents_md(start_dir: Union[str, Path]) -> List[Path]:
 
 
 def load_agents_md(
-    agents_md: Optional[Union[bool, str, List[str]]] = None,
+    agents_md: Any = _AUTO_DISCOVER,
     base_dir: Optional[Union[str, Path]] = None,
 ) -> str:
     """Load AGENTS.md content based on the configuration value.
 
     Args:
         agents_md: Configuration value controlling AGENTS.md loading:
-            - None (default): no auto-discovery, return ""
+            - Omitted: auto-discover from base_dir (or CWD) upward
+            - None: explicitly disabled, return ""
             - True: auto-discover from base_dir (or CWD) upward
             - False: explicitly disabled, return ""
             - str: explicit path to one file
@@ -72,7 +75,7 @@ def load_agents_md(
 
     paths: List[Path] = []
 
-    if agents_md is True:
+    if agents_md is _AUTO_DISCOVER or agents_md is True:
         dir_to_search = Path(base_dir) if base_dir else Path.cwd()
         paths = discover_agents_md(dir_to_search)
     elif isinstance(agents_md, str):

--- a/packages/tyler/tyler/models/completion_handler.py
+++ b/packages/tyler/tyler/models/completion_handler.py
@@ -3,7 +3,7 @@
 This module handles all LLM completion logic, including parameter building,
 model-specific adjustments, and response processing.
 """
-from typing import Dict, List, Any, Tuple, Optional
+from typing import Dict, List, Any, Tuple, Optional, Literal
 from datetime import datetime, UTC
 import copy
 import weave
@@ -38,7 +38,8 @@ class CompletionHandler:
         api_key: Optional[str] = None,
         extra_headers: Optional[Dict[str, str]] = None,
         drop_params: bool = True,
-        reasoning: Optional[Any] = None
+        reasoning: Optional[Any] = None,
+        instruction_role: Literal["system", "developer"] = "system",
     ):
         """Initialize the CompletionHandler.
         
@@ -50,6 +51,7 @@ class CompletionHandler:
             extra_headers: Optional additional headers
             drop_params: Whether to drop unsupported parameters
             reasoning: Unified reasoning config (string or dict)
+            instruction_role: Role used for the generated instruction prompt
         """
         self.model_name = model_name
         self.temperature = temperature
@@ -58,6 +60,7 @@ class CompletionHandler:
         self.extra_headers = extra_headers
         self.drop_params = drop_params
         self.reasoning = reasoning
+        self.instruction_role = instruction_role
     
     async def get_completion(
         self,
@@ -78,7 +81,7 @@ class CompletionHandler:
             Tuple of (response, metrics dict)
         """
         # Create completion messages with system prompt
-        completion_messages = [{"role": "system", "content": system_prompt}] + thread_messages
+        completion_messages = [self.build_instruction_message(system_prompt)] + thread_messages
         
         # Build parameters
         completion_params = self._build_completion_params(
@@ -153,6 +156,10 @@ class CompletionHandler:
             params.update(reasoning_params)
         
         return params
+
+    def build_instruction_message(self, content: str) -> Dict[str, str]:
+        """Build the instruction message prepended to model completion calls."""
+        return {"role": self.instruction_role, "content": content}
     
     def _map_reasoning_to_provider_params(self, reasoning: Any) -> Dict[str, Any]:
         """Map unified reasoning parameter to provider-specific format.
@@ -270,4 +277,3 @@ class CompletionHandler:
             }
         
         return metrics
-

--- a/packages/tyler/tyler/models/skill.py
+++ b/packages/tyler/tyler/models/skill.py
@@ -1,6 +1,6 @@
 """Skill model and manager for Agent Skills support.
 
-Implements the Agent Skills open format (https://agentskills.io/specification).
+Implements the Open Agent Skills format (https://openagentskills.dev/docs/specification).
 Skills are directories containing a SKILL.md file with YAML frontmatter
 (name, description) and markdown instructions. Skills are progressively
 disclosed - only metadata appears in the system prompt, and full instructions
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # Validation constraints per the Agent Skills spec
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
-NAME_PATTERN = re.compile(r'^[a-z0-9][a-z0-9-]*$')
+NAME_PATTERN = re.compile(r'^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$')
 
 
 @dataclass
@@ -193,7 +193,12 @@ class SkillManager:
             if skill is None:
                 available = ", ".join(sorted(skills.keys()))
                 return f"Unknown skill '{name}'. Available skills: {available}"
-            return skill.content
+            return (
+                f"Skill root: {skill.path}\n\n"
+                f"<skill_instructions name=\"{skill.name}\">\n"
+                f"{skill.content}\n"
+                f"</skill_instructions>"
+            )
 
         return activate_skill
 


### PR DESCRIPTION
Updates Tyler so AGENTS.md is auto-discovered by default with explicit disable support, adds agents_md_base_dir and instruction_role, and reuses the canonical system prompt across core completion paths and the CLI. Skills stay explicit, with stricter names and activate_skill now returning the skill root plus instructions. Adds directive spec/impact/TDR docs and updates Tyler docs/config examples for the new behavior. Tests: uv run pytest packages/tyler/tests/models/test_agents_md.py packages/tyler/tests/models/test_agent_skills.py packages/tyler/tests/models/test_agent.py::test_system_prompt_generation packages/tyler/tests/cli/test_chat_integration.py -q; cd packages/tyler && uv run pytest tests/.