### PR TITLE
Refresh Tyler MCP best practices

### DIFF
--- a/directive/specs/mcp-best-practices-refresh/impact.md
+++ b/directive/specs/mcp-best-practices-refresh/impact.md
@@ -1,0 +1,24 @@
+# Impact Analysis — MCP Best-Practices Refresh
+
+## Modules/packages likely touched
+- `packages/tyler/tyler/mcp/config_loader.py` for config validation, SDK parameter mapping, tool conversion, metadata preservation, and result serialization.
+- `packages/tyler/tyler/models/agent.py` and `packages/tyler/tyler/utils/tool_runner.py` for MCP tool lifecycle cleanup and reconnect behavior.
+- `packages/tyler/tests/mcp/`, `packages/tyler/tests/models/`, and `packages/tyler/tests/cli/` for TDD coverage.
+- `packages/tyler/examples/`, `packages/tyler/README.md`, `docs/guides/`, `docs/concepts/`, `docs/apps/`, `docs/api-reference/`, `docs/docs.json`, and Tyler YAML examples for updated MCP guidance.
+- Root `uv.lock` for the latest compatible `mcp` dependency resolution.
+
+## Contracts to update (APIs, events, schemas, migrations)
+- Public API remains `Agent(mcp={...})`, `await agent.connect_mcp()`, and `await agent.cleanup()`.
+- MCP config schema gains optional fields: `timeout_seconds`, `sse_read_timeout_seconds`, `terminate_on_close`, `tool_timeout_seconds`, `cwd`, `encoding`, and `encoding_error_handler`.
+- Tool attributes contract gains MCP metadata fields: server name, original name, SDK name, exposed name, `outputSchema`, annotations, icons, execution metadata, and `_meta`.
+- No database migrations, event schema changes, or A2A contract changes.
+
+## Risks
+- Security: MCP servers can execute code or access sensitive data. Mitigation is compatible hardening: stricter config validation, docs that treat MCP tools and annotations as untrusted unless reviewed, env var guidance for secrets, and include/exclude filters.
+- Performance/Availability: Remote MCP servers may hang or degrade agent runs. Mitigation is validated retry/timeout fields, SDK timeout propagation, and tool-level timeouts.
+- Data integrity: Tool name sanitization/truncation can collide. Mitigation is deterministic suffixing for long names and warnings for collisions.
+
+## Observability needs
+- Logs: Retain connection attempt, retry, connection failure, cleanup, and tool collision logs.
+- Metrics: No new metrics in this pass.
+- Alerts: No new alerts in this pass.

--- a/directive/specs/mcp-best-practices-refresh/spec.md
+++ b/directive/specs/mcp-best-practices-refresh/spec.md
@@ -1,0 +1,58 @@
+# Spec — MCP Best-Practices Refresh
+
+**Feature name**: MCP Best-Practices Refresh
+**One-line summary**: Refresh Tyler's MCP client integration, examples, and docs for the MCP 2025-11-25 stable spec while preserving the existing `Agent(mcp={...})` API.
+
+---
+
+## Problem
+Tyler's MCP docs and adapter behavior lag current MCP guidance. Remote MCP usage should present Streamable HTTP as the primary transport, `stdio` as the local process transport, and SSE only as legacy compatibility. The adapter should also preserve richer MCP tool metadata, validate configuration more defensively, serialize tool results safely, and clean up dynamically registered MCP tools so reconnects do not duplicate exposed tools.
+
+## Goal
+Tyler users can configure MCP servers through the current `Agent(mcp={...})` and `await agent.connect_mcp()` flow with updated transport framing, stricter validation, safer result handling, metadata preservation, and reliable cleanup/reconnect behavior.
+
+## Success Criteria
+- [ ] MCP config accepts only `stdio`, `streamablehttp`, and legacy `sse`, with no docs or examples claiming `websocket` support.
+- [ ] Tyler validates URL schemes, list/dict option types, positive retry/timeout values, and required transport fields before connection.
+- [ ] MCP tools exposed to providers use OpenAI-compatible function names while preserving original MCP names and metadata in attributes.
+- [ ] MCP tool results prefer structured content, serialize non-text content into JSON-compatible values, and raise on MCP `isError` results.
+- [ ] `cleanup()` removes MCP tools from exposed tools and allows reconnect without duplicate definitions.
+- [ ] Docs and examples recommend `try/finally await agent.cleanup()` and describe MCP tools as privileged/untrusted unless explicitly trusted.
+
+## User Story
+As a Tyler developer, I want MCP integration that follows current MCP guidance without changing Tyler's public API, so that I can connect reviewed local and remote MCP servers safely and predictably.
+
+## Flow / States
+Happy path: a user creates `Agent(mcp={...})`, Tyler validates the config, `await agent.connect_mcp()` connects servers, registers sanitized tool names with metadata, the model calls MCP tools, and `await agent.cleanup()` disconnects and removes dynamic MCP tools.
+
+Edge case: a user configures an invalid transport, URL, timeout, or option type. Tyler raises a clear `ValueError` at initialization rather than failing later during connection.
+
+## UX Links
+- Designs: N/A
+- Prototype: N/A
+- Copy/Content: MCP spec 2025-11-25, MCP transports, MCP security best practices, MCP Python SDK PyPI page
+
+## Requirements
+- Must keep `Agent(mcp={...})` and `await agent.connect_mcp()` as the public API.
+- Must not add provider-native OpenAI MCP support in this pass.
+- Must support only `stdio`, `streamablehttp`, and legacy `sse`.
+- Must add optional config fields for connection, read, process, encoding, and tool execution timeout behavior.
+- Must sanitize the full exposed Tyler MCP tool name to OpenAI-compatible function name constraints.
+- Must preserve MCP server/tool metadata in tool attributes.
+- Must remove dynamically registered MCP tools during cleanup.
+- Must update docs, examples, and CLI config comments to current MCP transport and security positioning.
+
+## Acceptance Criteria
+- Given MCP config with HTTP transport URL using a non-HTTP scheme, when creating an `Agent`, then Tyler raises `ValueError`.
+- Given MCP config with `websocket`, invalid option types, or non-positive retries/timeouts, when creating an `Agent`, then Tyler raises `ValueError`.
+- Given an MCP tool with special characters or an overlong server/tool name, when it is registered, then the exposed Tyler name is OpenAI-compatible and original names are preserved in attributes.
+- Given an MCP tool result with `structuredContent`, when called through Tyler, then Tyler returns that structured content.
+- Given an MCP tool result with non-text content, when called through Tyler, then Tyler returns JSON-serializable dictionaries instead of object repr strings.
+- Given an MCP tool result with `isError=True`, when called through Tyler, then Tyler raises a `ValueError`.
+- Given an agent with MCP tools, when `cleanup()` is called and then `connect_mcp()` is called again, then the tool list and system prompt do not contain duplicate MCP tool definitions and non-MCP prompt content is preserved.
+
+## Non-Goals
+- Provider-native OpenAI MCP integration.
+- MCP roots, elicitation UI, OAuth browser flows, progressive discovery runtime, or new trust/permission UI.
+- Breaking secure-default changes beyond compatible validation and hardening guidance.
+- Changes to A2A APIs.

--- a/directive/specs/mcp-best-practices-refresh/tdr.md
+++ b/directive/specs/mcp-best-practices-refresh/tdr.md
@@ -1,0 +1,94 @@
+# Technical Design Review (TDR) — MCP Best-Practices Refresh
+
+**Author**: Codex
+**Date**: 2026-06-04
+**Links**: Spec (`/directive/specs/mcp-best-practices-refresh/spec.md`), Impact (`/directive/specs/mcp-best-practices-refresh/impact.md`)
+
+---
+
+## 1. Summary
+Refresh Tyler's MCP integration around the MCP 2025-11-25 stable framing while keeping the existing cross-provider MCP SDK adapter as the integration path. The public API remains `Agent(mcp={...})`, `await agent.connect_mcp()`, and `await agent.cleanup()`.
+
+The implementation will tighten config validation, map current Python SDK transport options, preserve richer MCP tool metadata, safely serialize tool results, and make cleanup remove dynamically registered MCP tools so reconnects do not duplicate exposed definitions. Docs and examples will position Streamable HTTP as the default remote transport, `stdio` as the local transport, and SSE as legacy compatibility.
+
+## 2. Decision Drivers & Non-Goals
+- Drivers: current MCP spec alignment, cross-provider compatibility, predictable cleanup, safer defaults, and docs that reduce unsafe MCP server usage.
+- Non-Goals: provider-native OpenAI MCP, roots, elicitation UI, OAuth browser flow, progressive runtime discovery, and A2A API changes.
+
+## 3. Current State — Codebase Map
+- `packages/tyler/tyler/mcp/config_loader.py` validates Tyler MCP config, builds SDK `StdioServerParameters`, `SseServerParameters`, and `StreamableHttpParameters`, connects via `ClientSessionGroup`, converts SDK tools to Tyler dict tools, and creates closures that call `group.call_tool()`.
+- `packages/tyler/tyler/models/agent.py` validates MCP config in `__init__`, exposes `connect_mcp()`, appends MCP tool dicts to `self.tools`, rebuilds the tool manager, and stores an MCP disconnect callback. `cleanup()` currently disconnects but does not remove MCP tools from exposed tools.
+- `ToolRunner` registers tool implementations, definitions, attributes, and optional per-tool execution timeouts.
+- Existing tests cover basic validation, env substitution, parameter mapping, progress callbacks, collision avoidance, `connect_mcp()`, and cleanup basics.
+- Docs currently include MCP guides, concepts, API docs, CLI config docs, and Tyler examples. Some comments mention `websocket` and cleanup guidance is inconsistent.
+
+## 4. Proposed Design
+- Keep Tyler's SDK-backed adapter and public API unchanged.
+- Expand validation in `_validate_server_config()`:
+  - Require server dicts with string `name` and transport in `stdio`, `streamablehttp`, or `sse`.
+  - Require `command` for `stdio` and `url` for HTTP transports.
+  - Require `http` or `https` URL schemes for `streamablehttp` and legacy `sse`.
+  - Validate list fields (`args`, `include_tools`, `exclude_tools`), dict fields (`env`, `headers`), boolean fields (`fail_silent`, `terminate_on_close`), and positive numeric fields (`max_retries`, `timeout_seconds`, `sse_read_timeout_seconds`, `tool_timeout_seconds`).
+- Map optional SDK parameter fields in `_build_server_params()` only when supported by the installed SDK.
+- Sanitize the complete exposed name `<prefix>_<original_tool_name>` into OpenAI-compatible function names (`[A-Za-z0-9_-]`, max 64 chars), with deterministic hashing when truncation is needed.
+- Preserve MCP metadata in attributes, including server name, original name, SDK name, exposed name, schema/annotation/icon fields, execution metadata, and `_meta`.
+- Serialize tool call results with a helper:
+  - Raise when `isError` is true.
+  - Prefer `structuredContent`.
+  - Return a single text content item as a string.
+  - Return multiple text items as a list.
+  - Convert non-text content to JSON-compatible dictionaries using model dump APIs when available.
+- Track dynamic MCP tool names on the agent. On cleanup, disconnect and remove those tools from `self.tools`, `_processed_tools`, runner registries, attributes cache, and prompt text.
+
+## 5. Alternatives Considered
+- Add provider-native OpenAI MCP support now: rejected because it would fragment cross-provider behavior and is explicitly out of scope.
+- Keep permissive config validation: rejected because invalid transports, schemes, and timeout values fail late and obscure MCP trust boundaries.
+- Leave cleanup as disconnect-only: rejected because reconnect currently risks duplicate tool definitions and stale prompts.
+
+## 6. Data Model & Contract Changes
+- No persistent data model changes.
+- MCP config adds optional fields while preserving existing required fields.
+- Tool attribute metadata is additive and backward compatible.
+- A2A APIs remain unchanged; docs will clarify A2A is for agent-to-agent delegation, not general external tool integration.
+
+## 7. Security, Privacy, Compliance
+- MCP tools are privileged integrations and should be treated as untrusted unless the server is reviewed and trusted.
+- Secrets remain environment-variable based; examples avoid hardcoded secrets.
+- Tool annotations and descriptions are advisory and not a trust boundary.
+- Include/exclude filters are recommended to minimize exposed tools and avoid always-on large catalogs.
+
+## 8. Observability & Operations
+- Continue using existing logging for connection attempts, retry failures, disconnect errors, and name collisions.
+- No dashboards, alerts, or SLO changes in this pass.
+
+## 9. Rollout & Migration
+- Backward compatible for existing `stdio`, `streamablehttp`, and `sse` users with valid URLs/options.
+- Invalid config now fails fast at agent construction.
+- SSE remains supported as legacy compatibility.
+- Revert plan: revert MCP adapter/docs/test changes; no data migrations involved.
+
+## 10. Test Strategy & Spec Coverage (TDD)
+- TDD commitment: add failing tests first, confirm failures where practical, then implement.
+- Config validation tests: invalid transport, URL schemes, option types, positive values, and required transport fields.
+- Parameter mapping tests: optional timeout/read/process/encoding/cwd fields propagate into SDK parameter objects where supported.
+- Tool conversion tests: metadata preservation, full exposed name sanitization/truncation, include/exclude behavior, and collision warning compatibility.
+- Tool result tests: structured content preference, simple text returns, multiple/non-text content serialization, `isError` raises, progress callback, and read/progress timeout propagation.
+- Agent lifecycle tests: cleanup removes MCP tools, reconnect does not duplicate tools, system prompt regenerates after cleanup, and skills/AGENTS.md prompt content is preserved.
+- CLI/docs tests: YAML examples and docs do not claim `websocket`; examples recommend `try/finally await agent.cleanup()`.
+
+## 11. Risks & Open Questions
+- SDK parameter names may differ across compatible versions. Mitigation: inspect constructor signatures and set only supported fields.
+- Sanitized names may collide after truncation. Mitigation: deterministic suffixes and existing collision logging.
+- Some MCP content objects may have SDK-specific serialization shapes. Mitigation: prefer `model_dump()`/`dict()` and fall back to public non-callable attributes.
+
+## 12. Milestones / Plan
+- Add spec, impact, and TDR docs.
+- Add focused failing tests for MCP validation, mapping, metadata, result serialization, and lifecycle cleanup.
+- Implement adapter and lifecycle changes.
+- Update docs, examples, and YAML comments.
+- Refresh `uv.lock` for `mcp 1.27.2`.
+- Run the requested targeted test command.
+
+---
+
+**Approval Gate**: User supplied an implementation plan and asked to implement it in this workspace on 2026-06-04.

--- a/docs/api-reference/tyler-agent.mdx
+++ b/docs/api-reference/tyler-agent.mdx
@@ -273,6 +273,18 @@ mcp:
     - name: "docs"
       transport: "streamablehttp"
       url: "https://example.com/mcp"
+      timeout_seconds: 10
+      sse_read_timeout_seconds: 300
+      tool_timeout_seconds: 30
+      include_tools: ["search"]
+      headers:
+        Authorization: "Bearer ${MCP_TOKEN}"
+    - name: "local_files"
+      transport: "stdio"
+      command: "npx"
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"]
+      cwd: "/tmp"
+      encoding: "utf-8"
 
 # Environment variables (keeps secrets safe)
 api_key: "${OPENAI_API_KEY}"  # Reads from environment

--- a/docs/apps/tyler-cli.mdx
+++ b/docs/apps/tyler-cli.mdx
@@ -113,12 +113,15 @@ skills:
   - "./skills/code-review"
 
 # MCP Server Configuration (optional)
-# Connect to external docs, APIs, databases
+# Connect to reviewed external docs, APIs, databases.
+# Use streamablehttp for remote servers, stdio for local servers,
+# and sse only for legacy compatibility.
 # mcp:
 #   servers:
 #     - name: docs
-#       transport: sse
+#       transport: streamablehttp
 #       url: https://docs.example.com/mcp
+#       include_tools: ["search"]
 ```
 
 See the [MCP Integration Guide](/guides/mcp-integration) for full MCP configuration options.

--- a/docs/concepts/a2a.mdx
+++ b/docs/concepts/a2a.mdx
@@ -16,6 +16,10 @@ The Agent-to-Agent (A2A) Protocol is an open standard that enables AI agents fro
 - Receive real-time updates via push notifications
 - Enable seamless interoperability between different agent frameworks
 
+<Note>
+Use A2A for agent-to-agent delegation and interoperability. For general external tool or data-source integration, use [MCP](/concepts/mcp).
+</Note>
+
 **💻 Code Examples**
 
 <CardGroup cols={3}>

--- a/docs/concepts/mcp.mdx
+++ b/docs/concepts/mcp.mdx
@@ -35,6 +35,8 @@ The Model Context Protocol (MCP) is an open standard that enables seamless commu
 - Share context across applications
 - Build interoperable AI systems
 
+Tyler follows the MCP `2025-11-25` stable transport framing: Streamable HTTP is the default for remote servers, `stdio` is for local subprocess servers, and SSE is legacy compatibility.
+
 ## MCP Architecture in Slide
 
 ```mermaid
@@ -54,7 +56,7 @@ Tyler uses the official MCP SDK's `ClientSessionGroup` to manage connections to 
 - Automatic session lifecycle management
 - Tool discovery and aggregation across servers
 - Tool execution routing to the correct server
-- Support for all SDK transport types (stdio, SSE, StreamableHTTP)
+- Standard MCP transports (`stdio`, Streamable HTTP) plus legacy SSE compatibility
 
 ## Quick Start
 
@@ -79,21 +81,21 @@ async def main():
         }
     )
 
-    # Connect to MCP servers (fail fast!)
-    await agent.connect_mcp()
-    
-    # Use the agent - MCP tools are now available
-    thread = Thread()
-    thread.add_message(Message(
-        role="user",
-        content="How do I create a Tyler agent?"
-    ))
-    
-    result = await agent.run(thread)
-    print(result.content)
-    
-    # Cleanup MCP connections
-    await agent.cleanup()
+    try:
+        # Connect to MCP servers (fail fast!)
+        await agent.connect_mcp()
+        
+        # Use the agent - MCP tools are now available
+        thread = Thread()
+        thread.add_message(Message(
+            role="user",
+            content="How do I create a Tyler agent?"
+        ))
+        
+        result = await agent.run(thread)
+        print(result.content)
+    finally:
+        await agent.cleanup()
 
 if __name__ == "__main__":
     asyncio.run(main())
@@ -137,9 +139,9 @@ mcp={
 }
 ```
 
-### 2. StreamableHTTP Servers
+### 2. Streamable HTTP Servers
 
-HTTP-based servers using the newer streaming protocol. Recommended for hosted MCP servers:
+HTTP-based servers using the current remote transport. Recommended for hosted MCP servers:
 
 ```python
 mcp={
@@ -154,7 +156,7 @@ mcp={
 
 ### 3. SSE (Server-Sent Events) Servers
 
-Legacy HTTP transport for streaming connections:
+Legacy HTTP transport for backward compatibility with older MCP servers:
 
 ```python
 mcp={
@@ -237,12 +239,15 @@ agent = Agent(
     }
 )
 
-await agent.connect_mcp()
+try:
+    await agent.connect_mcp()
 
-# Agent now has tools from all servers:
-# - slide_SearchSlideFramework
-# - gh_search_repos
-# - filesystem_read_file, filesystem_list_directory
+    # Agent now has tools from all servers:
+    # - slide_SearchSlideFramework
+    # - gh_search_repos
+    # - filesystem_read_file, filesystem_list_directory
+finally:
+    await agent.cleanup()
 ```
 
 ### Tool Filtering
@@ -316,7 +321,7 @@ Control failure behavior per server:
 
 <AccordionGroup>
   <Accordion title="1. Connection Management">
-    Always cleanup MCP connections in long-running applications:
+    Always cleanup MCP connections:
     ```python
     agent = Agent(mcp={...})
     try:
@@ -324,15 +329,6 @@ Control failure behavior per server:
         # Use agent
     finally:
         await agent.cleanup()
-    ```
-    
-    For short scripts with `streamablehttp` transport, cleanup is required:
-    ```python
-    async def main():
-        agent = Agent(mcp={"servers": [{"transport": "streamablehttp", ...}]})
-        await agent.connect_mcp()
-        result = await agent.run(thread)
-        await agent.cleanup()  # Required for streamablehttp
     ```
   </Accordion>
 
@@ -346,7 +342,7 @@ Control failure behavior per server:
     "headers": {"Authorization": "Bearer sk-1234567890"}
     ```
     
-    Only connect to trusted MCP servers - they execute with your agent's permissions.
+    Only connect to reviewed MCP servers. MCP tools execute with your agent's permissions, local `stdio` servers run with the same privileges as Tyler, and tool annotations/metadata are advisory unless the server is trusted.
   </Accordion>
 
   <Accordion title="3. Tool Organization">

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -22,12 +22,12 @@
         "pages": [
           "guides/your-first-agent",
           "guides/adding-tools",
+          "guides/mcp-integration",
           "guides/skills",
           "guides/conversation-persistence",
           "guides/streaming-responses",
           "guides/agent-delegation",
           "guides/structured-output",
-          "guides/mcp-integration",
           "guides/a2a-integration",
           "guides/patterns",
           "guides/testing-agents"

--- a/docs/guides/a2a-integration.mdx
+++ b/docs/guides/a2a-integration.mdx
@@ -5,6 +5,10 @@ description: 'Step-by-step guide to integrating Agent-to-Agent (A2A) Protocol v0
 
 This guide walks you through integrating the Agent-to-Agent (A2A) Protocol v0.3.0 with your Tyler agents, enabling multi-agent coordination and delegation across different platforms.
 
+<Note>
+Use A2A when one agent delegates to or exposes another agent. Use [MCP](/guides/mcp-integration) for external tools, services, and data sources.
+</Note>
+
 **💻 Code Examples**
 
 <CardGroup cols={3}>

--- a/docs/guides/mcp-integration.mdx
+++ b/docs/guides/mcp-integration.mdx
@@ -3,7 +3,7 @@ title: 'MCP Integration'
 description: 'Connect your agents to Model Context Protocol servers using declarative config'
 ---
 
-Model Context Protocol (MCP) is an open standard for connecting AI applications to external data sources and tools. Tyler has first-class support for MCP through declarative configuration—no boilerplate code needed!
+Model Context Protocol (MCP) is an open standard for connecting AI applications to external data sources and tools. Tyler has first-class support for MCP through declarative configuration based on the MCP `2025-11-25` stable framing: Streamable HTTP for remote servers, `stdio` for local servers, and SSE only for legacy compatibility.
 
 **💻 Code Examples**
 
@@ -29,7 +29,7 @@ Model Context Protocol (MCP) is an open standard for connecting AI applications 
 ### Python API
 
 ```python
-from tyler import Agent
+from tyler import Agent, Thread, Message
 
 # Create agent with MCP config
 agent = Agent(
@@ -45,17 +45,16 @@ agent = Agent(
     }
 )
 
-# Connect to MCP servers (fail fast!)
-await agent.connect_mcp()
+try:
+    # Connect to MCP servers (fail fast!)
+    await agent.connect_mcp()
 
-# Use normally - MCP tools are now available
-thread = Thread()
-thread.add_message(Message(role="user", content="How do I create a Tyler agent?"))
-result = await agent.run(thread)
-
-# Optional: Cleanup MCP connections (not needed for scripts)
-# Useful for long-running apps or when creating many agents
-# await agent.cleanup()
+    # Use normally - MCP tools are now available
+    thread = Thread()
+    thread.add_message(Message(role="user", content="How do I create a Tyler agent?"))
+    result = await agent.run(thread)
+finally:
+    await agent.cleanup()
 ```
 
 ### CLI (tyler-chat)
@@ -105,13 +104,21 @@ Each MCP server requires:
     "command": str,     # Required for stdio
     "args": List[str],  # Optional for stdio
     "env": Dict,        # Optional for stdio
+    "cwd": str,         # Optional for stdio
+    "encoding": str,    # Optional for stdio
+    "encoding_error_handler": str,  # Optional for stdio: strict, ignore, replace
     
     # Optional fields:
     "headers": Dict,           # Custom HTTP headers (for streamablehttp/sse)
     "include_tools": List[str],  # Whitelist specific tools
     "exclude_tools": List[str],  # Blacklist specific tools
     "prefix": str,             # Custom namespace (default: server name)
-    "fail_silent": bool        # Continue if connection fails (default: true)
+    "fail_silent": bool,       # Continue if connection fails (default: true)
+    "max_retries": int,        # Positive retry count (default: 3)
+    "timeout_seconds": float,  # Connection/request timeout
+    "sse_read_timeout_seconds": float,  # Stream read timeout
+    "terminate_on_close": bool,  # Streamable HTTP session termination (default: true)
+    "tool_timeout_seconds": float  # Per-tool execution/read timeout
 }
 ```
 
@@ -136,7 +143,7 @@ Each MCP server requires:
 }
 ```
 
-**SSE (Server-Sent Events)** - Legacy HTTP transport (for backward compatibility):
+**SSE (Server-Sent Events)** - Legacy HTTP transport for backward compatibility:
 ```python
 {
     "name": "legacy_server",
@@ -155,14 +162,17 @@ Connect to multiple MCP servers simultaneously:
 agent = Agent(
     mcp={
         "servers": [
-            {"name": "docs", "transport": "sse", "url": "https://docs.example.com/mcp"},
-            {"name": "db", "transport": "sse", "url": "https://db.example.com/mcp"},
+            {"name": "docs", "transport": "streamablehttp", "url": "https://docs.example.com/mcp"},
+            {"name": "db", "transport": "streamablehttp", "url": "https://db.example.com/mcp"},
             {"name": "files", "transport": "stdio", "command": "mcp-server-files"}
         ]
     }
 )
 
-await agent.connect_mcp()  # Connects to all servers in parallel
+try:
+    await agent.connect_mcp()
+finally:
+    await agent.cleanup()
 ```
 
 ### Tool Filtering
@@ -187,7 +197,7 @@ Override the default namespace prefix:
 {
     "name": "wandb_documentation_server",  # Long name
     "prefix": "docs",  # Short, clean prefix
-    "transport": "sse",
+    "transport": "streamablehttp",
     "url": "https://docs.wandb.ai/mcp"
 }
 # Tools: docs_search, docs_query (instead of wandb_documentation_server_search)
@@ -238,7 +248,7 @@ Control failure behavior per server:
 
 ### When to Use `cleanup()`
 
-**MCP connections are automatically cleaned up** when your process ends. You only need explicit cleanup in:
+Use `try/finally` and call `await agent.cleanup()` whenever an agent connects to MCP servers. Cleanup disconnects SDK sessions and removes dynamically registered MCP tools from the agent so reconnects do not duplicate definitions.
 
 **Long-running applications:**
 ```python
@@ -246,10 +256,12 @@ Control failure behavior per server:
 @app.post("/chat")
 async def chat_endpoint(request):
     agent = Agent(mcp={...})
-    await agent.connect_mcp()
-    result = await agent.run(thread)
-    await agent.cleanup()  # ← Important! Free connection
-    return result
+    try:
+        await agent.connect_mcp()
+        result = await agent.run(thread)
+        return result
+    finally:
+        await agent.cleanup()
 ```
 
 **Testing or batch processing:**
@@ -257,40 +269,15 @@ async def chat_endpoint(request):
 # Creating/destroying many agents
 for task in tasks:
     agent = Agent(mcp={...})
-    await agent.connect_mcp()
-    await agent.run(thread)
-    await agent.cleanup()  # ← Prevent connection leak
-```
-
-**Short scripts DON'T need cleanup** (except streamablehttp):
-```python
-async def main():
-    agent = Agent(
-        mcp={"servers": [{"transport": "stdio", ...}]}  # stdio, sse, streamablehttp
-    )
-    await agent.connect_mcp()
-    result = await agent.run(thread)
-    # Done - no cleanup needed!
-
-asyncio.run(main())  # Connections close when process ends
-```
-
-**Exception: streamablehttp transport requires cleanup:**
-```python
-async def main():
-    agent = Agent(
-        mcp={"servers": [{"transport": "streamablehttp", ...}]}  # Mintlify
-    )
-    await agent.connect_mcp()
-    result = await agent.run(thread)
-    await agent.cleanup()  # ← Required for streamablehttp to avoid asyncio errors
-
-asyncio.run(main())
+    try:
+        await agent.connect_mcp()
+        await agent.run(thread)
+    finally:
+        await agent.cleanup()
 ```
 
 <Note>
-The `streamablehttp` transport uses asyncio task groups that require explicit cleanup,
-even in simple scripts. Other transports (stdio, sse) clean up automatically.
+Streamable HTTP uses asyncio task groups and remote sessions that especially need explicit cleanup. Using the same pattern for `stdio` and legacy `sse` keeps scripts and tests predictable.
 </Note>
 
 ## Security Best Practices
@@ -320,10 +307,12 @@ mcp:
         Authorization: "Bearer sk-1234567890"  # ✗ Bad - secret exposed!
 ```
 
-**Trust only verified MCP servers:**
-- Only connect to MCP servers you trust
-- MCP tools execute with your agent's permissions
-- Review tool capabilities before enabling
+**Harden MCP usage:**
+- Trust only reviewed MCP servers; local `stdio` servers run with the same privileges as the Tyler process.
+- Treat MCP tool descriptions, annotations, icons, and `_meta` as advisory/untrusted unless the server is trusted.
+- Prefer `include_tools` and `exclude_tools` so agents only see the tools they need.
+- Avoid always-on large MCP server catalogs; connect narrow server sets per agent or workflow.
+- Keep secrets in environment variables and use `${VAR}` substitution in config.
 
 ## Troubleshooting
 
@@ -342,7 +331,7 @@ mcp:
 **Error:** `Server 'xyz' with transport 'sse' requires 'url' field`
 
 **Solution:** Ensure required fields are present for the transport type:
-- SSE/Streamablehttp: `url` required
+- streamablehttp/SSE: `url` required
 - stdio: `command` required
 
 ### Tools not discovered

--- a/packages/tyler/README.md
+++ b/packages/tyler/README.md
@@ -115,10 +115,11 @@ Tyler's tools are provided by the `slide-lye` package. Extend agent capabilities
 Integrates with the Model Context Protocol for:
 - Seamless connection to MCP-compatible servers
 - Automatic tool discovery from MCP servers
-- Support for multiple transport protocols (WebSocket, SSE, STDIO)
+- Streamable HTTP for remote servers, stdio for local servers, and legacy SSE compatibility
 - Server lifecycle management
 - Dynamic tool invocation
 - Integration with any MCP-compatible tool ecosystem
+- Tool filtering and env-var based secrets for safer privileged integrations
 
 ### Skills
 

--- a/packages/tyler/examples/300_mcp_basic.py
+++ b/packages/tyler/examples/300_mcp_basic.py
@@ -57,38 +57,40 @@ async def main():
     print("Connecting to MCP server...")
     try:
         await agent.connect_mcp()
+    except Exception as e:
+        print(f"✗ Failed to connect: {e}")
+        await agent.cleanup()
+        return
+    
+    try:
         print(f"✓ Connected! Tools available: {len(agent._processed_tools)}")
         
         # Show MCP tools
         mcp_tools = [t["function"]["name"] for t in agent._processed_tools if "docs_" in t["function"]["name"]]
         print(f"  MCP tools: {mcp_tools}\n")
-    except Exception as e:
-        print(f"✗ Failed to connect: {e}")
-        return
-    
-    # Create a thread with a question
-    thread = Thread()
-    thread.add_message(Message(
-        role="user",
-        content="How do I create my first Tyler agent? Give me a quick example."
-    ))
-    
-    # Process with streaming
-    print("💬 User: How do I create my first Tyler agent? Give me a quick example.")
-    print("\n🤖 DocsBot: ", end="", flush=True)
-    
-    async for event in agent.stream(thread):
-        if event.type.name == "LLM_STREAM_CHUNK":
-            print(event.data.get("content_chunk", ""), end="", flush=True)
-        elif event.type.name == "TOOL_SELECTED":
-            tool_name = event.data.get("tool_name")
-            print(f"\n\n  [Using tool: {tool_name}]", flush=True)
-            print("\n🤖 DocsBot: ", end="", flush=True)
-        elif event.type.name == "EXECUTION_COMPLETE":
-            print("\n\n✓ Complete!")
-    
-    # Cleanup MCP connections
-    await agent.cleanup()
+        
+        # Create a thread with a question
+        thread = Thread()
+        thread.add_message(Message(
+            role="user",
+            content="How do I create my first Tyler agent? Give me a quick example."
+        ))
+        
+        # Process with streaming
+        print("💬 User: How do I create my first Tyler agent? Give me a quick example.")
+        print("\n🤖 DocsBot: ", end="", flush=True)
+        
+        async for event in agent.stream(thread):
+            if event.type.name == "LLM_STREAM_CHUNK":
+                print(event.data.get("content_chunk", ""), end="", flush=True)
+            elif event.type.name == "TOOL_SELECTED":
+                tool_name = event.data.get("tool_name")
+                print(f"\n\n  [Using tool: {tool_name}]", flush=True)
+                print("\n🤖 DocsBot: ", end="", flush=True)
+            elif event.type.name == "EXECUTION_COMPLETE":
+                print("\n\n✓ Complete!")
+    finally:
+        await agent.cleanup()
     
     print("\n" + "=" * 70)
     print("Example complete!")
@@ -124,18 +126,19 @@ async def brave_search_example():
         }
     )
     
-    await agent.connect_mcp()
-    
-    thread = Thread()
-    thread.add_message(Message(
-        role="user",
-        content="What's the latest news about AI?"
-    ))
-    
-    result = await agent.run(thread)
-    print(f"\nBrave Search Response:\n{result.content}")
-    
-    await agent.cleanup()
+    try:
+        await agent.connect_mcp()
+        
+        thread = Thread()
+        thread.add_message(Message(
+            role="user",
+            content="What's the latest news about AI?"
+        ))
+        
+        result = await agent.run(thread)
+        print(f"\nBrave Search Response:\n{result.content}")
+    finally:
+        await agent.cleanup()
 
 
 if __name__ == "__main__":

--- a/packages/tyler/examples/301_mcp_advanced.py
+++ b/packages/tyler/examples/301_mcp_advanced.py
@@ -66,41 +66,38 @@ async def example_multiple_servers():
         }
     )
     
-    # Connect to all servers
-    print("\nConnecting to MCP servers...")
-    await agent.connect_mcp()
-    
-    # Show connected tools
-    print(f"✓ Agent has {len(agent._processed_tools)} tools total")
-    
-    # Show MCP tools grouped by server
-    slide_tools = [t["function"]["name"] for t in agent._processed_tools if "slide_" in t["function"]["name"]]
-    gh_tools = [t["function"]["name"] for t in agent._processed_tools if "gh_" in t["function"]["name"]]
-    
-    print(f"  Slide docs tools ({len(slide_tools)}): {slide_tools}")
-    print(f"  GitHub tools ({len(gh_tools)}): {gh_tools}")
-    
-    # Use the agent
-    thread = Thread()
-    thread.add_message(Message(
-        role="user",
-        content="Search the Slide docs for information about MCP"
-    ))
-    
-    print("\n💬 User: Search the Slide docs for information about MCP")
-    print("🤖 Tyler: ", end="", flush=True)
-    
-    async for event in agent.stream(thread):
-        if event.type.name == "LLM_STREAM_CHUNK":
-            print(event.data.get("content_chunk", ""), end="", flush=True)
-        elif event.type.name == "EXECUTION_COMPLETE":
-            print("\n")
-    
-    # Cleanup MCP connections (stdio connections may raise CancelledError)
     try:
+        # Connect to all servers
+        print("\nConnecting to MCP servers...")
+        await agent.connect_mcp()
+        
+        # Show connected tools
+        print(f"✓ Agent has {len(agent._processed_tools)} tools total")
+        
+        # Show MCP tools grouped by server
+        slide_tools = [t["function"]["name"] for t in agent._processed_tools if "slide_" in t["function"]["name"]]
+        gh_tools = [t["function"]["name"] for t in agent._processed_tools if "gh_" in t["function"]["name"]]
+        
+        print(f"  Slide docs tools ({len(slide_tools)}): {slide_tools}")
+        print(f"  GitHub tools ({len(gh_tools)}): {gh_tools}")
+        
+        # Use the agent
+        thread = Thread()
+        thread.add_message(Message(
+            role="user",
+            content="Search the Slide docs for information about MCP"
+        ))
+        
+        print("\n💬 User: Search the Slide docs for information about MCP")
+        print("🤖 Tyler: ", end="", flush=True)
+        
+        async for event in agent.stream(thread):
+            if event.type.name == "LLM_STREAM_CHUNK":
+                print(event.data.get("content_chunk", ""), end="", flush=True)
+            elif event.type.name == "EXECUTION_COMPLETE":
+                print("\n")
+    finally:
         await agent.cleanup()
-    except asyncio.CancelledError:
-        pass  # Expected for stdio connections during cleanup
 
 
 async def example_tool_filtering():
@@ -125,7 +122,7 @@ async def example_tool_filtering():
             },
             {
                 "name": "api",
-                "transport": "sse",
+                "transport": "streamablehttp",
                 "url": "https://api.example.com/mcp",
                 "include_tools": ["search", "query"],  # Whitelist specific tools
                 "fail_silent": True
@@ -152,7 +149,7 @@ async def example_authentication():
     config = {
         "servers": [{
             "name": "private_api",
-            "transport": "sse",
+            "transport": "streamablehttp",
             "url": "https://api.example.com/mcp",
             "headers": {
                 # Always use environment variables for secrets!
@@ -210,7 +207,10 @@ mcp:
     print("  import yaml")
     print("  config = yaml.safe_load(open('tyler-config.yaml'))")
     print("  agent = Agent(**config)")
-    print("  await agent.connect_mcp()")
+    print("  try:")
+    print("      await agent.connect_mcp()")
+    print("  finally:")
+    print("      await agent.cleanup()")
 
 
 async def main():
@@ -241,4 +241,3 @@ async def main():
 
 if __name__ == "__main__":
     asyncio.run(main())
-

--- a/packages/tyler/examples/303_mcp_progress_callback.py
+++ b/packages/tyler/examples/303_mcp_progress_callback.py
@@ -90,6 +90,7 @@ async def example_with_real_progress():
         f.write(MCP_SERVER_CODE)
         server_script = f.name
     
+    agent = None
     try:
         # Create agent connected to our progress-enabled server
         # Using gpt-4o for more reliable tool calling
@@ -171,10 +172,10 @@ async def example_with_real_progress():
                     print(f"\n  Progress event details:")
                     for i, pe in enumerate(progress_events):
                         print(f"    {i+1}. {pe['progress']}/{pe['total']} - {pe['message']}")
-        
-        await agent.cleanup()
-        
     finally:
+        if agent is not None:
+            await agent.cleanup()
+
         # Clean up temp file
         try:
             os.unlink(server_script)
@@ -200,6 +201,7 @@ async def example_custom_callback():
         f.write(MCP_SERVER_CODE)
         server_script = f.name
     
+    agent = None
     try:
         # Custom progress tracking
         progress_log = []
@@ -260,10 +262,10 @@ async def example_custom_callback():
             print("  Progress log:")
             for entry in progress_log:
                 print(f"    - {entry['progress']}/{entry['total']} - {entry['message']}")
-        
-        await agent.cleanup()
-        
     finally:
+        if agent is not None:
+            await agent.cleanup()
+
         try:
             os.unlink(server_script)
         except OSError as e:

--- a/packages/tyler/tests/cli/test_init.py
+++ b/packages/tyler/tests/cli/test_init.py
@@ -1,5 +1,7 @@
 """Tests for the Tyler init scaffolding."""
 
+from pathlib import Path
+
 from tyler.cli.init import create_agent_py
 
 
@@ -12,3 +14,19 @@ def test_init_agent_template_uses_agent_result_contract(tmp_path):
     assert "result = await agent.run(thread)" in generated
     assert "for msg in result.new_messages:" in generated
     assert "processed_thread, new_messages = await agent.go(thread)" not in generated
+
+
+def test_mcp_docs_and_config_do_not_claim_websocket_transport():
+    """MCP docs/config examples should not advertise websocket support."""
+    root = Path(__file__).resolve().parents[4]
+    files = [
+        root / "packages/tyler/tyler-chat-config.yaml",
+        root / "packages/tyler/README.md",
+        root / "docs/guides/mcp-integration.mdx",
+        root / "docs/concepts/mcp.mdx",
+        root / "docs/apps/tyler-cli.mdx",
+    ]
+
+    for path in files:
+        content = path.read_text().lower()
+        assert "websocket" not in content, f"{path} still claims MCP websocket support"

--- a/packages/tyler/tests/mcp/test_config_loader.py
+++ b/packages/tyler/tests/mcp/test_config_loader.py
@@ -6,6 +6,7 @@ and the SDK-based ClientSessionGroup integration.
 import pytest
 import os
 import re
+import asyncio
 from datetime import timedelta
 from types import SimpleNamespace
 from unittest.mock import patch, AsyncMock, MagicMock
@@ -17,6 +18,7 @@ from tyler.mcp.config_loader import (
     _build_server_params,
     _create_tool_implementation,
     _convert_tools_for_agent,
+    _json_safe,
 )
 from mcp.client.session_group import (
     StdioServerParameters,
@@ -342,6 +344,10 @@ class TestBuildServerParams:
 
 class TestToolConversion:
     """Test tool conversion to Tyler format."""
+
+    def test_json_safe_ignores_unittest_mock_values(self):
+        """Test mock-only dynamic attributes are not serialized as MCP metadata."""
+        assert _json_safe(MagicMock()) is None
     
     def test_convert_tools_with_prefix(self):
         """Test tools are converted with prefix."""
@@ -727,6 +733,38 @@ class TestLoadMCPConfig:
         
         assert tools == []
         await disconnect()  # Should not raise
+
+    async def test_disconnect_ignores_sdk_internal_cancelled_error(self):
+        """Test MCP cleanup ignores CancelledError when the current task is not cancelling."""
+        config = {"servers": []}
+
+        with patch('tyler.mcp.config_loader.AsyncExitStack') as mock_stack_class:
+            mock_stack = MagicMock()
+            mock_stack.__aenter__ = AsyncMock()
+            mock_stack.aclose = AsyncMock(side_effect=asyncio.CancelledError())
+            mock_stack_class.return_value = mock_stack
+
+            tools, disconnect = await _load_mcp_config(config)
+
+            assert tools == []
+            await disconnect()
+            mock_stack.aclose.assert_called_once()
+
+    async def test_disconnect_reraises_real_task_cancellation(self):
+        """Test MCP cleanup does not swallow cancellation of the running task."""
+        config = {"servers": []}
+
+        with patch('tyler.mcp.config_loader.AsyncExitStack') as mock_stack_class:
+            mock_stack = MagicMock()
+            mock_stack.__aenter__ = AsyncMock()
+            mock_stack.aclose = AsyncMock(side_effect=asyncio.CancelledError())
+            mock_stack_class.return_value = mock_stack
+
+            _, disconnect = await _load_mcp_config(config)
+
+            with patch('tyler.mcp.config_loader._current_task_is_cancelling', return_value=True):
+                with pytest.raises(asyncio.CancelledError):
+                    await disconnect()
     
     async def test_load_mcp_config_connection_success(self):
         """Test loading config with successful connection."""

--- a/packages/tyler/tests/mcp/test_config_loader.py
+++ b/packages/tyler/tests/mcp/test_config_loader.py
@@ -5,6 +5,9 @@ and the SDK-based ClientSessionGroup integration.
 """
 import pytest
 import os
+import re
+from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import patch, AsyncMock, MagicMock
 from tyler.mcp.config_loader import (
     _validate_mcp_config,
@@ -37,6 +40,13 @@ class TestValidation:
         config = {"servers": "not-a-list"}
         
         with pytest.raises(ValueError, match="must be a list"):
+            _validate_mcp_config(config)
+
+    def test_validate_mcp_config_server_not_dict(self):
+        """Test validation fails when a server entry is not a dict."""
+        config = {"servers": ["not-a-dict"]}
+
+        with pytest.raises(ValueError, match="must be a dict"):
             _validate_mcp_config(config)
     
     def test_validate_mcp_config_valid(self):
@@ -75,6 +85,48 @@ class TestValidation:
         }
         
         with pytest.raises(ValueError, match="Invalid transport 'http'"):
+            _validate_server_config(server)
+
+    @pytest.mark.parametrize("transport", ["sse", "streamablehttp"])
+    def test_validate_server_config_rejects_non_http_url_scheme(self, transport):
+        """Test HTTP transports require http or https URL schemes."""
+        server = {
+            "name": "test",
+            "transport": transport,
+            "url": "ftp://example.com/mcp",
+        }
+
+        with pytest.raises(ValueError, match="must use http or https URL scheme"):
+            _validate_server_config(server)
+
+    @pytest.mark.parametrize(
+        "field,value,match",
+        [
+            ("args", "not-a-list", "must be a list"),
+            ("include_tools", "search", "must be a list"),
+            ("exclude_tools", "delete", "must be a list"),
+            ("env", ["KEY=value"], "must be a dict"),
+            ("headers", ["Authorization"], "must be a dict"),
+            ("max_retries", 0, "must be a positive integer"),
+            ("timeout_seconds", 0, "must be a positive number"),
+            ("sse_read_timeout_seconds", -1, "must be a positive number"),
+            ("tool_timeout_seconds", 0, "must be a positive number"),
+            ("terminate_on_close", "false", "must be a boolean"),
+            ("cwd", 123, "must be a string"),
+            ("encoding", 123, "must be a string"),
+            ("encoding_error_handler", "explode", "must be one of"),
+        ],
+    )
+    def test_validate_server_config_rejects_invalid_option_types(self, field, value, match):
+        """Test optional MCP config fields are type-checked."""
+        server = {
+            "name": "test",
+            "transport": "stdio",
+            "command": "npx",
+            field: value,
+        }
+
+        with pytest.raises(ValueError, match=match):
             _validate_server_config(server)
     
     def test_validate_server_config_sse_missing_url(self):
@@ -139,7 +191,15 @@ class TestValidation:
         server = {
             "name": "mintlify",
             "transport": "streamablehttp",
-            "url": "https://slide.mintlify.app/mcp"
+            "url": "https://slide.mintlify.app/mcp",
+            "headers": {"Authorization": "Bearer ${MCP_TOKEN}"},
+            "timeout_seconds": 10,
+            "sse_read_timeout_seconds": 300,
+            "tool_timeout_seconds": 30,
+            "terminate_on_close": True,
+            "include_tools": ["search"],
+            "exclude_tools": ["delete"],
+            "max_retries": 2,
         }
         
         # Should not raise
@@ -223,7 +283,10 @@ class TestBuildServerParams:
             "transport": "stdio",
             "command": "npx",
             "args": ["-y", "server"],
-            "env": {"NODE_ENV": "production"}
+            "env": {"NODE_ENV": "production"},
+            "cwd": "/tmp",
+            "encoding": "utf-8",
+            "encoding_error_handler": "replace",
         }
         
         params = _build_server_params(server)
@@ -232,6 +295,9 @@ class TestBuildServerParams:
         assert params.command == "npx"
         assert params.args == ["-y", "server"]
         assert params.env == {"NODE_ENV": "production"}
+        assert str(params.cwd) == "/tmp"
+        assert params.encoding == "utf-8"
+        assert params.encoding_error_handler == "replace"
     
     def test_build_sse_params(self):
         """Test building SseServerParameters."""
@@ -239,7 +305,9 @@ class TestBuildServerParams:
             "name": "test",
             "transport": "sse",
             "url": "https://example.com/mcp",
-            "headers": {"Authorization": "Bearer token"}
+            "headers": {"Authorization": "Bearer token"},
+            "timeout_seconds": 7.5,
+            "sse_read_timeout_seconds": 120,
         }
         
         params = _build_server_params(server)
@@ -247,6 +315,8 @@ class TestBuildServerParams:
         assert isinstance(params, SseServerParameters)
         assert params.url == "https://example.com/mcp"
         assert params.headers == {"Authorization": "Bearer token"}
+        assert params.timeout == 7.5
+        assert params.sse_read_timeout == 120
     
     def test_build_streamablehttp_params(self):
         """Test building StreamableHttpParameters."""
@@ -254,7 +324,10 @@ class TestBuildServerParams:
             "name": "test",
             "transport": "streamablehttp",
             "url": "https://example.com/mcp",
-            "headers": {"X-API-Key": "key123"}
+            "headers": {"X-API-Key": "key123"},
+            "timeout_seconds": 12,
+            "sse_read_timeout_seconds": 240,
+            "terminate_on_close": False,
         }
         
         params = _build_server_params(server)
@@ -262,6 +335,9 @@ class TestBuildServerParams:
         assert isinstance(params, StreamableHttpParameters)
         assert params.url == "https://example.com/mcp"
         assert params.headers == {"X-API-Key": "key123"}
+        assert params.timeout == timedelta(seconds=12)
+        assert params.sse_read_timeout == timedelta(seconds=240)
+        assert params.terminate_on_close is False
 
 
 class TestToolConversion:
@@ -355,6 +431,80 @@ class TestToolConversion:
         
         assert tools[0]["definition"]["function"]["name"] == "my_server_name_search"
 
+    def test_convert_tools_sanitizes_full_exposed_name(self):
+        """Test prefix and original MCP name are sanitized as one exposed tool name."""
+        mock_group = MagicMock()
+        mock_tool = MagicMock()
+        mock_tool.name = "search.documents/v1"
+        mock_tool.description = "Test"
+        mock_tool.inputSchema = {}
+        mock_group.tools = {"_0_search.documents/v1": mock_tool}
+
+        tools = _convert_tools_for_agent(
+            mock_group, {"_0_search.documents/v1"}, "docs.example", None, []
+        )
+
+        exposed_name = tools[0]["definition"]["function"]["name"]
+        assert exposed_name == "docs_example_search_documents_v1"
+        assert re.fullmatch(r"[A-Za-z0-9_-]{1,64}", exposed_name)
+        assert tools[0]["attributes"]["mcp_original_name"] == "search.documents/v1"
+
+    def test_convert_tools_truncates_openai_function_names(self):
+        """Test long exposed names are truncated to OpenAI's 64-character limit."""
+        mock_group = MagicMock()
+        mock_tool = MagicMock()
+        mock_tool.name = "tool-" + ("x" * 80)
+        mock_tool.description = "Test"
+        mock_tool.inputSchema = {}
+        mock_group.tools = {"_0_long": mock_tool}
+
+        tools = _convert_tools_for_agent(
+            mock_group, {"_0_long"}, "server-" + ("y" * 80), None, []
+        )
+
+        exposed_name = tools[0]["definition"]["function"]["name"]
+        assert re.fullmatch(r"[A-Za-z0-9_-]{1,64}", exposed_name)
+        assert len(exposed_name) <= 64
+        assert tools[0]["attributes"]["mcp_original_name"] == mock_tool.name
+
+    def test_convert_tools_preserves_mcp_metadata(self):
+        """Test MCP tool metadata is preserved in Tyler tool attributes."""
+        mock_group = MagicMock()
+        mock_tool = SimpleNamespace(
+            name="search",
+            description="Search",
+            inputSchema={"type": "object", "properties": {}},
+            outputSchema={"type": "object", "properties": {"answer": {"type": "string"}}},
+            annotations={"readOnlyHint": True},
+            icons=[{"src": "https://example.com/icon.png", "mimeType": "image/png"}],
+            execution={"timeout": 30},
+            meta={"vendor": "example"},
+        )
+        mock_group.tools = {"_0_search": mock_tool}
+
+        tools = _convert_tools_for_agent(
+            mock_group,
+            {"_0_search"},
+            "docs",
+            None,
+            [],
+            server_name="docs-server",
+            tool_timeout_seconds=45,
+        )
+
+        attrs = tools[0]["attributes"]
+        assert attrs["mcp_server_name"] == "docs-server"
+        assert attrs["mcp_original_name"] == "search"
+        assert attrs["mcp_sdk_name"] == "_0_search"
+        assert attrs["mcp_exposed_name"] == "docs_search"
+        assert attrs["mcp_output_schema"] == mock_tool.outputSchema
+        assert attrs["mcp_annotations"] == {"readOnlyHint": True}
+        assert attrs["mcp_icons"] == mock_tool.icons
+        assert attrs["mcp_execution"] == mock_tool.execution
+        assert attrs["mcp_meta"] == {"vendor": "example"}
+        assert attrs["mcp_tool_timeout_seconds"] == 45
+        assert tools[0]["timeout"] == 45
+
 
 class TestToolImplementation:
     """Test tool implementation creation."""
@@ -410,6 +560,66 @@ class TestToolImplementation:
         result = await impl()
         
         assert result == ["Result 1", "Result 2"]
+
+    @pytest.mark.asyncio
+    async def test_tool_implementation_serializes_non_text_content(self):
+        """Test non-text MCP content is returned as JSON-serializable dictionaries."""
+        from mcp.types import ImageContent
+
+        mock_group = MagicMock()
+        mock_result = MagicMock()
+        mock_result.structuredContent = None
+        mock_result.isError = False
+        mock_result.content = [
+            ImageContent(type="image", data="abc123", mimeType="image/png")
+        ]
+        mock_group.call_tool = AsyncMock(return_value=mock_result)
+
+        impl = _create_tool_implementation(mock_group, "_0_test_tool", "test_tool")
+        result = await impl()
+
+        assert result == {"type": "image", "data": "abc123", "mimeType": "image/png"}
+
+    @pytest.mark.asyncio
+    async def test_tool_implementation_raises_on_mcp_error_result(self):
+        """Test MCP isError results raise instead of returning error content."""
+        mock_group = MagicMock()
+        mock_result = MagicMock()
+        mock_result.structuredContent = None
+        mock_result.isError = True
+        mock_result.content = [MagicMock(text="permission denied")]
+        mock_group.call_tool = AsyncMock(return_value=mock_result)
+
+        impl = _create_tool_implementation(mock_group, "_0_test_tool", "test_tool")
+
+        with pytest.raises(ValueError, match="permission denied"):
+            await impl()
+
+    @pytest.mark.asyncio
+    async def test_tool_implementation_passes_read_timeout(self):
+        """Test tool_timeout_seconds propagates to MCP SDK read_timeout_seconds."""
+        mock_group = MagicMock()
+        mock_result = MagicMock()
+        mock_result.structuredContent = None
+        mock_result.isError = False
+        mock_result.content = [MagicMock(text="Result text")]
+        mock_group.call_tool = AsyncMock(return_value=mock_result)
+
+        impl = _create_tool_implementation(
+            mock_group,
+            "_0_test_tool",
+            "test_tool",
+            tool_timeout_seconds=9,
+        )
+        result = await impl(arg1="value")
+
+        assert result == "Result text"
+        mock_group.call_tool.assert_called_once_with(
+            "_0_test_tool",
+            {"arg1": "value"},
+            progress_callback=None,
+            read_timeout_seconds=timedelta(seconds=9),
+        )
     
     @pytest.mark.asyncio
     async def test_tool_implementation_passes_progress_callback(self):

--- a/packages/tyler/tests/models/test_agent_mcp.py
+++ b/packages/tyler/tests/models/test_agent_mcp.py
@@ -242,6 +242,16 @@ class TestAgentCleanup:
             # Verify disconnect was called
             mock_disconnect.assert_called_once()
             assert not agent._mcp_connected
+
+            tool_names = [t["function"]["name"] for t in agent._processed_tools]
+            assert "test_tool" not in tool_names
+            assert "test_tool" not in agent._tool_runner.tools
+            assert all(
+                tool.get("definition", {}).get("function", {}).get("name") != "test_tool"
+                for tool in agent.tools
+                if isinstance(tool, dict)
+            )
+            assert "test_tool" not in agent._system_prompt
     
     async def test_cleanup_without_mcp_connection(self):
         """Test cleanup() works even if MCP never connected."""
@@ -285,3 +295,57 @@ class TestAgentCleanup:
             # Should have called _load_mcp_config twice
             assert mock_load.call_count == 2
 
+            tool_names = [t["function"]["name"] for t in agent._processed_tools]
+            assert tool_names.count("test_tool") == 1
+
+    async def test_cleanup_regenerates_prompt_preserving_skills_and_agents_md(self, tmp_path):
+        """Test cleanup removes MCP tools while preserving skills and AGENTS.md prompt content."""
+        agents_file = tmp_path / "AGENTS.md"
+        agents_file.write_text("MCP lifecycle project instruction.")
+        skill_dir = tmp_path / "skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: lifecycle-skill\ndescription: Lifecycle skill metadata\n---\nSkill body."
+        )
+
+        agent = Agent(
+            name="TestAgent",
+            model_name="gpt-4o-mini",
+            agents_md=str(agents_file),
+            skills=[str(skill_dir)],
+            mcp={
+                "servers": [{
+                    "name": "test",
+                    "transport": "streamablehttp",
+                    "url": "https://example.com/mcp",
+                }]
+            },
+        )
+
+        with patch('tyler.mcp.config_loader._load_mcp_config') as mock_load:
+            mock_load.return_value = (
+                [{
+                    "definition": {
+                        "type": "function",
+                        "function": {
+                            "name": "mcp_search",
+                            "description": "MCP Search",
+                            "parameters": {},
+                        },
+                    },
+                    "implementation": AsyncMock(),
+                    "attributes": {"source": "mcp"},
+                }],
+                AsyncMock(),
+            )
+
+            await agent.connect_mcp()
+            assert "mcp_search" in agent._system_prompt
+            assert "MCP lifecycle project instruction." in agent._system_prompt
+            assert "Lifecycle skill metadata" in agent._system_prompt
+
+            await agent.cleanup()
+
+            assert "mcp_search" not in agent._system_prompt
+            assert "MCP lifecycle project instruction." in agent._system_prompt
+            assert "Lifecycle skill metadata" in agent._system_prompt

--- a/packages/tyler/tyler-chat-config-wandb.yaml
+++ b/packages/tyler/tyler-chat-config-wandb.yaml
@@ -60,11 +60,12 @@ tools:
 #   - "./skills/code-review"
 
 # MCP (Model Context Protocol) Server Configuration
-# Connect to external documentation, APIs, databases via MCP servers
+# Use streamablehttp for remote servers, stdio for local servers, and sse only
+# for legacy compatibility. Treat MCP servers as privileged integrations.
 # Example: Slide documentation via Mintlify MCP
 # mcp:
 #   servers:
 #     - name: slide_docs
-#       transport: streamablehttp  # Mintlify uses streamablehttp transport
+#       transport: streamablehttp  # Remote MCP servers should use Streamable HTTP
 #       url: https://slide.mintlify.app/mcp
 #       # Tools will be available as: slide_docs_SearchSlideFramework, etc.

--- a/packages/tyler/tyler-chat-config.yaml
+++ b/packages/tyler/tyler-chat-config.yaml
@@ -50,13 +50,16 @@ tools:
 #   - "./skills/testing"
 
 # MCP (Model Context Protocol) Server Configuration
-# Connect to external documentation, APIs, databases via MCP servers
+# Connect to reviewed external documentation, APIs, databases via MCP servers.
+# Use streamablehttp for remote servers, stdio for local servers, and sse only
+# for legacy compatibility. Treat MCP tools and annotations as untrusted unless
+# you explicitly trust the server.
 # Uncomment to enable:
 mcp:
   servers:
     # Example: Mintlify documentation server (like Slide docs)
     - name: docs
-      transport: streamablehttp   # Transports: streamablehttp (Mintlify), stdio, sse, websocket
+      transport: streamablehttp   # Transports: streamablehttp, stdio, sse (legacy)
       url: https://slide.mintlify.app/mcp
       # fail_silent: true  # Default - continues if server unavailable (recommended)
 #       # Optional: Custom headers for authentication
@@ -65,5 +68,9 @@ mcp:
 #       # Optional: Filter tools
 #       # include_tools: ["search", "query"]
 #       # exclude_tools: ["delete"]
+#       # Optional: Connection/read/tool timeouts
+#       # timeout_seconds: 10
+#       # sse_read_timeout_seconds: 300
+#       # tool_timeout_seconds: 30
 #       # Optional: Custom namespace prefix (default: server name)
 #       # prefix: "docs"

--- a/packages/tyler/tyler/mcp/config_loader.py
+++ b/packages/tyler/tyler/mcp/config_loader.py
@@ -9,8 +9,12 @@ import os
 import re
 import logging
 import asyncio
+import hashlib
+import inspect
 from contextlib import AsyncExitStack
+from datetime import timedelta
 from typing import Dict, List, Any, Callable, Awaitable, Tuple, Optional, TYPE_CHECKING
+from urllib.parse import urlparse
 
 from mcp.client.session_group import (
     ClientSessionGroup,
@@ -26,6 +30,18 @@ logger = logging.getLogger(__name__)
 
 # Regex pattern for environment variable substitution: ${VAR_NAME}
 ENV_VAR_PATTERN = r'\$\{([^}]+)\}'
+OPENAI_FUNCTION_NAME_MAX_LENGTH = 64
+OPENAI_FUNCTION_NAME_PATTERN = r'[^a-zA-Z0-9_]'
+SUPPORTED_TRANSPORTS = ("stdio", "streamablehttp", "sse")
+LIST_OPTION_FIELDS = ("args", "include_tools", "exclude_tools")
+DICT_OPTION_FIELDS = ("env", "headers")
+POSITIVE_NUMBER_FIELDS = (
+    "timeout_seconds",
+    "sse_read_timeout_seconds",
+    "tool_timeout_seconds",
+)
+STRING_OPTION_FIELDS = ("cwd", "encoding")
+ENCODING_ERROR_HANDLERS = ("strict", "ignore", "replace")
 
 # Internal parameter name for ToolContext injection.
 # Uses a unique name that won't collide with real MCP tool parameters.
@@ -60,6 +76,9 @@ def _validate_mcp_config(config: Dict[str, Any]) -> None:
         config = {"servers": [{"name": "test", "transport": "sse", "url": "https://..."}]}
         _validate_mcp_config(config)  # Validates, raises if invalid
     """
+    if not isinstance(config, dict):
+        raise ValueError("MCP config must be a dict")
+
     if "servers" not in config:
         raise ValueError("MCP config must have 'servers' key")
     
@@ -69,6 +88,39 @@ def _validate_mcp_config(config: Dict[str, Any]) -> None:
     # Validate each server
     for server in config["servers"]:
         _validate_server_config(server)
+
+
+def _validate_list_field(server_name: str, server: Dict[str, Any], field: str) -> None:
+    """Validate optional list-valued server fields."""
+    if field in server and not isinstance(server[field], list):
+        raise ValueError(f"Server '{server_name}' field '{field}' must be a list")
+
+
+def _validate_dict_field(server_name: str, server: Dict[str, Any], field: str) -> None:
+    """Validate optional dict-valued server fields."""
+    if field in server and not isinstance(server[field], dict):
+        raise ValueError(f"Server '{server_name}' field '{field}' must be a dict")
+
+
+def _validate_positive_number_field(server_name: str, server: Dict[str, Any], field: str) -> None:
+    """Validate optional positive numeric server fields."""
+    if field not in server:
+        return
+    value = server[field]
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value <= 0:
+        raise ValueError(f"Server '{server_name}' field '{field}' must be a positive number")
+
+
+def _validate_url_scheme(server_name: str, transport: str, url: str) -> None:
+    """Validate HTTP transport URL schemes while allowing unresolved env placeholders."""
+    if re.search(ENV_VAR_PATTERN, url):
+        return
+
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(
+            f"Server '{server_name}' with transport '{transport}' must use http or https URL scheme"
+        )
 
 
 def _validate_server_config(server: Dict[str, Any]) -> None:
@@ -81,33 +133,77 @@ def _validate_server_config(server: Dict[str, Any]) -> None:
     Raises:
         ValueError: If server config is invalid
     """
+    if not isinstance(server, dict):
+        raise ValueError("Server config must be a dict")
+
     # Required fields
     if "name" not in server:
         raise ValueError("Server config missing required field 'name'")
+
+    if not isinstance(server["name"], str) or not server["name"].strip():
+        raise ValueError("Server config field 'name' must be a non-empty string")
+
+    server_name = server["name"]
     
     if "transport" not in server:
-        raise ValueError(f"Server '{server['name']}' missing required field 'transport'")
+        raise ValueError(f"Server '{server_name}' missing required field 'transport'")
     
     transport = server["transport"]
+    if not isinstance(transport, str):
+        raise ValueError(f"Server '{server_name}' field 'transport' must be a string")
     
     # Validate transport type
-    # Note: websocket is not supported by the MCP SDK's ClientSessionGroup
-    if transport not in ["stdio", "sse", "streamablehttp"]:
+    if transport not in SUPPORTED_TRANSPORTS:
         raise ValueError(
             f"Invalid transport '{transport}'. Must be one of: stdio, sse, streamablehttp"
+        )
+
+    for field in LIST_OPTION_FIELDS:
+        _validate_list_field(server_name, server, field)
+
+    for field in DICT_OPTION_FIELDS:
+        _validate_dict_field(server_name, server, field)
+
+    if "max_retries" in server:
+        max_retries = server["max_retries"]
+        if isinstance(max_retries, bool) or not isinstance(max_retries, int) or max_retries <= 0:
+            raise ValueError(f"Server '{server_name}' field 'max_retries' must be a positive integer")
+
+    for field in POSITIVE_NUMBER_FIELDS:
+        _validate_positive_number_field(server_name, server, field)
+
+    if "fail_silent" in server and not isinstance(server["fail_silent"], bool):
+        raise ValueError(f"Server '{server_name}' field 'fail_silent' must be a boolean")
+
+    if "terminate_on_close" in server and not isinstance(server["terminate_on_close"], bool):
+        raise ValueError(f"Server '{server_name}' field 'terminate_on_close' must be a boolean")
+
+    for field in STRING_OPTION_FIELDS:
+        if field in server and not isinstance(server[field], str):
+            raise ValueError(f"Server '{server_name}' field '{field}' must be a string")
+
+    if "encoding_error_handler" in server and server["encoding_error_handler"] not in ENCODING_ERROR_HANDLERS:
+        raise ValueError(
+            f"Server '{server_name}' field 'encoding_error_handler' must be one of: "
+            f"{', '.join(ENCODING_ERROR_HANDLERS)}"
         )
     
     # Transport-specific required fields
     if transport in ["sse", "streamablehttp"]:
         if "url" not in server:
             raise ValueError(
-                f"Server '{server['name']}' with transport '{transport}' requires 'url' field"
+                f"Server '{server_name}' with transport '{transport}' requires 'url' field"
             )
+        if not isinstance(server["url"], str) or not server["url"].strip():
+            raise ValueError(f"Server '{server_name}' field 'url' must be a non-empty string")
+        _validate_url_scheme(server_name, transport, server["url"])
     elif transport == "stdio":
         if "command" not in server:
             raise ValueError(
-                f"Server '{server['name']}' with transport 'stdio' requires 'command' field"
+                f"Server '{server_name}' with transport 'stdio' requires 'command' field"
             )
+        if not isinstance(server["command"], str) or not server["command"].strip():
+            raise ValueError(f"Server '{server_name}' field 'command' must be a non-empty string")
 
 
 def _substitute_env_vars(obj: Any) -> Any:
@@ -151,24 +247,156 @@ def _build_server_params(server: Dict[str, Any]):
     transport = server["transport"]
     
     if transport == "stdio":
-        return StdioServerParameters(
-            command=server["command"],
-            args=server.get("args", []),
-            env=server.get("env"),
-        )
+        return StdioServerParameters(**_supported_kwargs(
+            StdioServerParameters,
+            {
+                "command": server["command"],
+                "args": server.get("args", []),
+                "env": server.get("env"),
+                "cwd": server.get("cwd"),
+                "encoding": server.get("encoding", "utf-8"),
+                "encoding_error_handler": server.get("encoding_error_handler", "strict"),
+            },
+        ))
     elif transport == "sse":
-        return SseServerParameters(
-            url=server["url"],
-            headers=server.get("headers"),
-        )
+        return SseServerParameters(**_supported_kwargs(
+            SseServerParameters,
+            {
+                "url": server["url"],
+                "headers": server.get("headers"),
+                "timeout": server.get("timeout_seconds", 5),
+                "sse_read_timeout": server.get("sse_read_timeout_seconds", 300),
+            },
+        ))
     else:  # streamablehttp
-        return StreamableHttpParameters(
-            url=server["url"],
-            headers=server.get("headers"),
-        )
+        timeout = timedelta(seconds=server.get("timeout_seconds", 30))
+        sse_read_timeout = timedelta(seconds=server.get("sse_read_timeout_seconds", 300))
+        return StreamableHttpParameters(**_supported_kwargs(
+            StreamableHttpParameters,
+            {
+                "url": server["url"],
+                "headers": server.get("headers"),
+                "timeout": timeout,
+                "sse_read_timeout": sse_read_timeout,
+                "terminate_on_close": server.get("terminate_on_close", True),
+            },
+        ))
 
 
-def _create_tool_implementation(group: ClientSessionGroup, sdk_tool_name: str, display_name: str):
+def _supported_kwargs(callable_obj: Callable[..., Any], kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    """Return only keyword arguments supported by an SDK constructor/function."""
+    supported = set(inspect.signature(callable_obj).parameters)
+    return {key: value for key, value in kwargs.items() if key in supported}
+
+
+def _sanitize_tool_name(name: str) -> str:
+    """Sanitize a Tyler-exposed MCP tool name for OpenAI function-name constraints."""
+    sanitized = re.sub(OPENAI_FUNCTION_NAME_PATTERN, "_", str(name))
+    sanitized = re.sub(r"_+", "_", sanitized).strip("_")
+    if not sanitized:
+        sanitized = "mcp_tool"
+
+    if len(sanitized) > OPENAI_FUNCTION_NAME_MAX_LENGTH:
+        digest = hashlib.sha1(sanitized.encode("utf-8")).hexdigest()[:8]
+        prefix_len = OPENAI_FUNCTION_NAME_MAX_LENGTH - len(digest) - 1
+        sanitized = f"{sanitized[:prefix_len]}_{digest}"
+
+    return sanitized
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert SDK/Pydantic/dataclass-like values to JSON-serializable structures."""
+    try:
+        from unittest.mock import Mock
+        if isinstance(value, Mock):
+            return None
+    except Exception:
+        pass
+
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+
+    if isinstance(value, dict):
+        return {str(k): _json_safe(v) for k, v in value.items()}
+
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(v) for v in value]
+
+    if hasattr(value, "model_dump") and callable(value.model_dump):
+        try:
+            return value.model_dump(mode="json", by_alias=True, exclude_none=True)
+        except TypeError:
+            return value.model_dump()
+
+    if hasattr(value, "dict") and callable(value.dict):
+        try:
+            return value.dict(by_alias=True, exclude_none=True)
+        except TypeError:
+            return value.dict()
+
+    if hasattr(value, "__dict__"):
+        return {
+            key: _json_safe(val)
+            for key, val in vars(value).items()
+            if not key.startswith("_") and not callable(val)
+        }
+
+    return str(value)
+
+
+def _get_optional_tool_attr(tool: Any, *names: str) -> Any:
+    """Read optional SDK tool metadata without treating MagicMock fallbacks as real values."""
+    for name in names:
+        if isinstance(tool, dict) and name in tool:
+            return tool[name]
+        try:
+            value = getattr(tool, name)
+        except AttributeError:
+            continue
+        safe_value = _json_safe(value)
+        if safe_value is not None:
+            return value
+    return None
+
+
+def _serialize_mcp_tool_result(result: Any) -> Any:
+    """Serialize an MCP CallToolResult into Tyler-safe tool output."""
+    if getattr(result, "isError", False) is True:
+        error_content = _serialize_mcp_content(getattr(result, "content", []))
+        raise ValueError(error_content)
+
+    structured_content = getattr(result, "structuredContent", None)
+    if structured_content is not None:
+        return _json_safe(structured_content)
+
+    content = getattr(result, "content", None)
+    if content:
+        return _serialize_mcp_content(content)
+
+    return ""
+
+
+def _serialize_mcp_content(content: Any) -> Any:
+    """Serialize MCP content items, returning plain text directly when simple."""
+    serialized = []
+    for item in content:
+        text = getattr(item, "text", None)
+        if isinstance(text, str):
+            serialized.append(text)
+        else:
+            serialized.append(_json_safe(item))
+
+    if len(serialized) == 1:
+        return serialized[0]
+    return serialized
+
+
+def _create_tool_implementation(
+    group: ClientSessionGroup,
+    sdk_tool_name: str,
+    display_name: str,
+    tool_timeout_seconds: Optional[float] = None,
+):
     """
     Create a closure that calls the SDK's call_tool with the SDK-namespaced tool name.
     
@@ -201,28 +429,14 @@ def _create_tool_implementation(group: ClientSessionGroup, sdk_tool_name: str, d
                 progress_callback = _agent_ctx.progress_callback
                 logger.debug(f"MCP tool '{display_name}' will use progress callback")
             
-            result = await group.call_tool(
-                sdk_tool_name, 
-                kwargs,
-                progress_callback=progress_callback,
-            )
+            call_kwargs = {"progress_callback": progress_callback}
+            if tool_timeout_seconds is not None:
+                call_kwargs["read_timeout_seconds"] = timedelta(seconds=tool_timeout_seconds)
+
+            result = await group.call_tool(sdk_tool_name, kwargs, **call_kwargs)
             logger.debug(f"MCP tool '{display_name}' returned: {type(result)}")
             
-            # Prefer structuredContent if available (new SDK feature for tools with output schemas)
-            if hasattr(result, 'structuredContent') and result.structuredContent is not None:
-                return result.structuredContent
-            
-            # Extract text content from the result
-            if result.content:
-                texts = []
-                for c in result.content:
-                    if hasattr(c, 'text'):
-                        texts.append(c.text)
-                    else:
-                        texts.append(str(c))
-                return texts[0] if len(texts) == 1 else texts
-            
-            return str(result)
+            return _serialize_mcp_tool_result(result)
             
         except Exception as e:
             error_msg = f"Error calling MCP tool '{display_name}': {e}"
@@ -231,7 +445,7 @@ def _create_tool_implementation(group: ClientSessionGroup, sdk_tool_name: str, d
             raise ValueError(error_msg) from e
     
     # Set function metadata for better debugging
-    call_mcp_tool.__name__ = f"mcp_{display_name}"
+    call_mcp_tool.__name__ = _sanitize_tool_name(f"mcp_{display_name}")
     call_mcp_tool.__doc__ = f"MCP tool: {display_name}"
     # Mark as MCP tool so ToolRunner skips weave.op wrapping
     # (MCP SDK already provides its own Weave tracing)
@@ -246,6 +460,9 @@ def _convert_tools_for_agent(
     prefix: str,
     include_tools: Optional[List[str]],
     exclude_tools: List[str],
+    server_name: Optional[str] = None,
+    tool_timeout_seconds: Optional[float] = None,
+    transport: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Convert SDK tools to Tyler format with prefix and filtering.
@@ -260,8 +477,6 @@ def _convert_tools_for_agent(
     Returns:
         List of Tyler tool definitions ready for Agent
     """
-    # Sanitize prefix (alphanumeric + underscore only)
-    clean_prefix = re.sub(r'[^a-zA-Z0-9_]', '_', prefix)
     tyler_tools = []
     
     for sdk_tool_name, tool in group.tools.items():
@@ -280,10 +495,38 @@ def _convert_tools_for_agent(
         if original_name in exclude_tools:
             continue
         
-        # Create prefixed name for Tyler (e.g., "myserver_search")
-        prefixed_name = f"{clean_prefix}_{original_name}"
-        
-        tyler_tools.append({
+        # Create a provider-compatible name for Tyler (e.g., "myserver_search").
+        prefixed_name = _sanitize_tool_name(f"{prefix}_{original_name}")
+
+        attributes = {
+            "source": "mcp",
+            "mcp_server_name": server_name or prefix,
+            "mcp_original_name": original_name,
+            "mcp_sdk_name": sdk_tool_name,
+            "mcp_exposed_name": prefixed_name,
+        }
+        if transport:
+            attributes["mcp_transport"] = transport
+
+        optional_metadata = {
+            "mcp_output_schema": _get_optional_tool_attr(tool, "outputSchema"),
+            "mcp_annotations": _get_optional_tool_attr(tool, "annotations"),
+            "mcp_icons": _get_optional_tool_attr(tool, "icons"),
+            "mcp_execution": _get_optional_tool_attr(tool, "execution"),
+            "mcp_meta": _get_optional_tool_attr(tool, "meta", "_meta"),
+        }
+        for attr_name, attr_value in optional_metadata.items():
+            safe_value = _json_safe(attr_value)
+            if safe_value is not None:
+                attributes[attr_name] = safe_value
+
+        if "mcp_execution" in attributes:
+            attributes["mcp_execution_metadata"] = attributes["mcp_execution"]
+
+        if tool_timeout_seconds is not None:
+            attributes["mcp_tool_timeout_seconds"] = tool_timeout_seconds
+
+        tyler_tool = {
             "definition": {
                 "type": "function",
                 "function": {
@@ -293,13 +536,18 @@ def _convert_tools_for_agent(
                 }
             },
             # Closure uses SDK-namespaced name for correct routing
-            "implementation": _create_tool_implementation(group, sdk_tool_name, original_name),
-            "attributes": {
-                "source": "mcp",
-                "mcp_original_name": original_name,
-                "mcp_sdk_name": sdk_tool_name,
-            },
-        })
+            "implementation": _create_tool_implementation(
+                group,
+                sdk_tool_name,
+                original_name,
+                tool_timeout_seconds=tool_timeout_seconds,
+            ),
+            "attributes": attributes,
+        }
+        if tool_timeout_seconds is not None:
+            tyler_tool["timeout"] = tool_timeout_seconds
+
+        tyler_tools.append(tyler_tool)
     
     return tyler_tools
 
@@ -324,8 +572,9 @@ async def _load_mcp_config(
     Raises:
         ValueError: If server connection fails and fail_silent=False
     """
-    # Substitute environment variables
+    # Substitute environment variables and validate resolved values.
     config = _substitute_env_vars(config)
+    _validate_mcp_config(config)
     
     # Connection counter for SDK-level namespacing to avoid tool collisions
     # When two servers have tools with the same name (e.g., both have "search"),
@@ -359,6 +608,7 @@ async def _load_mcp_config(
             prefix = server.get("prefix", name)  # Use custom prefix or server name
             include_tools = server.get("include_tools")
             exclude_tools = server.get("exclude_tools", [])
+            tool_timeout_seconds = server.get("tool_timeout_seconds")
             
             # Build SDK server parameters
             params = _build_server_params(server)
@@ -407,6 +657,9 @@ async def _load_mcp_config(
                     prefix,
                     include_tools,
                     exclude_tools,
+                    server_name=name,
+                    tool_timeout_seconds=tool_timeout_seconds,
+                    transport=transport,
                 )
                 
                 # Check for prefixed name collisions with tools from previous servers

--- a/packages/tyler/tyler/mcp/config_loader.py
+++ b/packages/tyler/tyler/mcp/config_loader.py
@@ -289,6 +289,24 @@ def _supported_kwargs(callable_obj: Callable[..., Any], kwargs: Dict[str, Any]) 
     return {key: value for key, value in kwargs.items() if key in supported}
 
 
+def _current_task_is_cancelling() -> bool:
+    """Return True when the current asyncio task is being externally cancelled."""
+    current_task = asyncio.current_task()
+    return bool(current_task and current_task.cancelling())
+
+
+async def _close_exit_stack(exit_stack: AsyncExitStack, context: str) -> None:
+    """Close an MCP exit stack while ignoring SDK-internal cancellation noise."""
+    try:
+        await exit_stack.aclose()
+    except asyncio.CancelledError:
+        if _current_task_is_cancelling():
+            raise
+        logger.warning(f"MCP {context} was cancelled during cleanup; treating resources as closed")
+    except Exception as e:
+        logger.warning(f"Error during MCP {context}: {e}")
+
+
 def _sanitize_tool_name(name: str) -> str:
     """Sanitize a Tyler-exposed MCP tool name for OpenAI function-name constraints."""
     sanitized = re.sub(OPENAI_FUNCTION_NAME_PATTERN, "_", str(name))
@@ -306,12 +324,8 @@ def _sanitize_tool_name(name: str) -> str:
 
 def _json_safe(value: Any) -> Any:
     """Convert SDK/Pydantic/dataclass-like values to JSON-serializable structures."""
-    try:
-        from unittest.mock import Mock
-        if isinstance(value, Mock):
-            return None
-    except Exception:
-        pass
+    if type(value).__module__ == "unittest.mock":
+        return None
 
     if value is None or isinstance(value, (str, int, float, bool)):
         return value
@@ -682,10 +696,7 @@ async def _load_mcp_config(
         # Create disconnect callback that closes the exit stack
         async def disconnect_callback():
             """Disconnect from all MCP servers."""
-            try:
-                await exit_stack.aclose()
-            except Exception as e:
-                logger.warning(f"Error during MCP disconnect: {e}")
+            await _close_exit_stack(exit_stack, "disconnect")
         
         returned_successfully = True
         return all_tools, disconnect_callback
@@ -694,7 +705,4 @@ async def _load_mcp_config(
         # If we didn't return successfully, clean up the exit stack
         # (on success, the caller is responsible for calling disconnect_callback)
         if not returned_successfully:
-            try:
-                await exit_stack.aclose()
-            except Exception as e:
-                logger.warning(f"Error cleaning up exit stack after failure: {e}")
+            await _close_exit_stack(exit_stack, "cleanup after failure")

--- a/packages/tyler/tyler/models/agent.py
+++ b/packages/tyler/tyler/models/agent.py
@@ -462,6 +462,7 @@ class Agent(BaseModel):
     _tool_runner: ToolRunner = PrivateAttr(default_factory=ToolRunner)
     _mcp_connected: bool = PrivateAttr(default=False)
     _mcp_disconnect: Optional[Callable[[], Awaitable[None]]] = PrivateAttr(default=None)
+    _mcp_tool_names: set[str] = PrivateAttr(default_factory=set)
     _tool_context: Optional[Dict[str, Any]] = PrivateAttr(default=None)
     _response_format: Optional[str] = PrivateAttr(default=None)
     _weave_agents_tracer: Optional[WeaveAgentsTracer] = PrivateAttr(default=None)
@@ -578,6 +579,50 @@ class Agent(BaseModel):
             skills_description=self._skills_description,
             agents_md_content=self._agents_md_content
         )
+
+    def _tool_name_from_definition(self, tool: Any) -> Optional[str]:
+        """Return a tool function name from Tyler tool dict shapes."""
+        if not isinstance(tool, dict):
+            return None
+
+        definition = tool.get("definition", tool)
+        if not isinstance(definition, dict):
+            return None
+
+        function = definition.get("function")
+        if not isinstance(function, dict):
+            return None
+
+        name = function.get("name")
+        return name if isinstance(name, str) else None
+
+    def _remove_mcp_tools_from_state(self) -> None:
+        """Remove dynamically registered MCP tools from agent and runner state."""
+        if not self._mcp_tool_names:
+            return
+
+        mcp_tool_names = set(self._mcp_tool_names)
+
+        if isinstance(self.tools, list):
+            self.tools = [
+                tool
+                for tool in self.tools
+                if self._tool_name_from_definition(tool) not in mcp_tool_names
+            ]
+
+        self._processed_tools = [
+            tool
+            for tool in self._processed_tools
+            if self._tool_name_from_definition(tool) not in mcp_tool_names
+        ]
+
+        for tool_name in mcp_tool_names:
+            self._tool_runner.unregister_tool(tool_name)
+            if self._tool_runner is not tool_runner:
+                tool_runner.unregister_tool(tool_name)
+            self._tool_attributes_cache.pop(tool_name, None)
+
+        self._mcp_tool_names.clear()
 
     def _build_instruction_message(self, content: str) -> Dict[str, str]:
         """Build the instruction message prepended to model completion calls."""
@@ -2311,6 +2356,9 @@ class Agent(BaseModel):
         if self._mcp_connected:
             logging.getLogger(__name__).debug("MCP already connected, skipping")
             return
+
+        # Clear any stale MCP tools left after a previous partial lifecycle before reconnecting.
+        self._remove_mcp_tools_from_state()
         
         logging.getLogger(__name__).info("Connecting to MCP servers...")
         
@@ -2318,9 +2366,14 @@ class Agent(BaseModel):
         
         # Connect and get tools (fails fast if server unreachable)
         mcp_tools, disconnect_callback = await _load_mcp_config(self.mcp)
+        mcp_tool_names = {
+            name for name in (self._tool_name_from_definition(tool) for tool in mcp_tools)
+            if name
+        }
         
         # Store disconnect callback
         self._mcp_disconnect = disconnect_callback
+        self._mcp_tool_names = mcp_tool_names
         
         # Merge MCP tools
         if not isinstance(self.tools, list):
@@ -2352,6 +2405,14 @@ class Agent(BaseModel):
         Agent can be reused by calling connect_mcp() again if needed.
         """
         if self._mcp_disconnect:
-            await self._mcp_disconnect()
-            self._mcp_disconnect = None
-            self._mcp_connected = False 
+            try:
+                await self._mcp_disconnect()
+            finally:
+                self._mcp_disconnect = None
+                self._mcp_connected = False
+                self._remove_mcp_tools_from_state()
+                self._regenerate_system_prompt()
+        elif self._mcp_tool_names:
+            self._mcp_connected = False
+            self._remove_mcp_tools_from_state()
+            self._regenerate_system_prompt()

--- a/packages/tyler/tyler/utils/tool_runner.py
+++ b/packages/tyler/tyler/utils/tool_runner.py
@@ -200,6 +200,11 @@ class ToolRunner:
             attributes: Dictionary of tool-specific attributes
         """
         self.tool_attributes[name] = attributes
+
+    def unregister_tool(self, name: str) -> None:
+        """Remove a registered tool and its attributes if present."""
+        self.tools.pop(name, None)
+        self.tool_attributes.pop(name, None)
         
     def get_tool_attributes(self, name: str) -> Optional[Dict[str, Any]]:
         """

--- a/packages/tyler/tyler/utils/tool_strategies.py
+++ b/packages/tyler/tyler/utils/tool_strategies.py
@@ -169,7 +169,8 @@ class DictToolStrategy(ToolRegistrationStrategy):
         tool_runner.register_tool(
             name=tool_name,
             implementation=tool['implementation'],
-            definition=tool['definition']['function']
+            definition=tool['definition']['function'],
+            timeout=tool.get('timeout')
         )
         
         # Register any attributes
@@ -338,4 +339,3 @@ class ToolRegistrar:
                 return strategy
         
         return None
-

--- a/uv.lock
+++ b/uv.lock
@@ -2107,7 +2107,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.25.0"
+version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2125,9 +2125,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/2d/649d80a0ecf6a1f82632ca44bec21c0461a9d9fc8934d38cb5b319f2db5e/mcp-1.25.0.tar.gz", hash = "sha256:56310361ebf0364e2d438e5b45f7668cbb124e158bb358333cd06e49e83a6802", size = 605387, upload-time = "2025-12-19T10:19:56.985Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/fc/6dc7659c2ae5ddf280477011f4213a74f806862856b796ef08f028e664bf/mcp-1.25.0-py3-none-any.whl", hash = "sha256:b37c38144a666add0862614cc79ec276e97d72aa8ca26d622818d4e278b9721a", size = 233076, upload-time = "2025-12-19T10:19:55.416Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates Tyler's MCP client path for the MCP 2025-11-25 guidance while keeping Agent(mcp={...}) and connect_mcp() as the public API. Adds stricter MCP config validation, SDK timeout/transport option mapping, safe tool-name sanitization, metadata preservation, safer result serialization, and cleanup that unregisters dynamic MCP tools before reconnect. Refreshes tests, docs, examples, CLI config guidance, directive specs, and uv.lock for mcp 1.27.2. Verified with: uv run pytest packages/tyler/tests/mcp packages/tyler/tests/models/test_agent_mcp.py packages/tyler/tests/models/test_agents_md.py packages/tyler/tests/models/test_agent_skills.py packages/tyler/tests/cli.